### PR TITLE
fix bug where app crashes because of Could not cast value of type 'NS…

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -837,9 +837,9 @@ extension MainViewController {
         for i in 0..<basal.count {
             let dict = basal[i] as! Dictionary<String, Any>
             do {
-                let thisValue = try dict[keyPath: "value"] as! Double
+                let thisValue = try (dict[keyPath: "value"] as! NSString).doubleValue
                 let thisTime = dict[keyPath: "time"] as! String
-                let thisTimeAsSeconds = dict[keyPath: "timeAsSeconds"] as! Double
+                let thisTimeAsSeconds = try (dict[keyPath: "timeAsSeconds"] as! NSString).doubleValue
                 let entry = basalProfileStruct(value: thisValue, time: thisTime, timeAsSeconds: thisTimeAsSeconds)
                 basalProfile.append(entry)
             } catch {


### PR DESCRIPTION
My app kept crashing when it received data from NightScout when I compiled it and ran on my phone.  
I found I got the error: 
```
Could not cast value of type 'NSTaggedPointerString' to 'NSNumber'
```

I found a way to fix the error by using this suggestion from Stack Overflow: 
https://stackoverflow.com/questions/33299202/could-not-cast-value-of-type-nstaggedpointerstring-to-nsnumber