### PR TITLE
Handling Optional Duration in Basal Data Processing

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1319,7 +1319,7 @@ extension MainViewController {
                 priorDateFormatter.timeZone = TimeZone(abbreviation: "UTC")
                 guard let priorDateString = dateFormatter.date(from: priorStrippedZone) else { continue }
                 let priorDateTimeStamp = priorDateString.timeIntervalSince1970
-                let priorDuration = priorEntry?["duration"] as! Double
+                let priorDuration = priorEntry?["duration"] as? Double ?? 0.0
                 // if difference between time stamps is greater than the duration of the last entry, there is a gap. Give a 15 second leeway on the timestamp
                 if Double( dateTimeStamp - priorDateTimeStamp ) > Double( (priorDuration * 60) + 15 ) {
                     


### PR DESCRIPTION
### Title: Handling Optional Duration in Basal Data Processing

This PR addresses a potential issue in the processing of basal data where the `duration` field might not be present or could be null. By using optional chaining and the nil-coalescing operator, we provide a default value of `0.0` for such cases. This makes the code more resilient to unexpected or malformed data. 

The specific line of code being modified is: 

    let priorDuration = priorEntry?["duration"] as? Double ?? 0.0

This change ensures that if `duration` is not available in the `priorEntry`, it will default to `0.0`, preventing any runtime crashes due to unwrapping a nil value. This approach provides a more robust and fail-safe mechanism to handle the optional duration.

Importantly, this code change has been tested by the user who originally encountered this issue and confirmed as resolved. I have also conducted further tests without encountering any issues. 