### PR TITLE
Multiple loopers

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -10,10 +10,10 @@
 unique_id = ${DEVELOPMENT_TEAM}
 
 
-// To build multiple instances of LoopFollow, uncomment the next two lines
-// and replace "Bob" with the desired app name for this instance:
-display_name = Bob
-unique_id = $(display_name)
+// To build multiple instances of LoopFollow, remove the // on
+// the next two lines and replace "Bob" with the desired app name for this instance:
+//display_name = Bob
+//unique_id = $(display_name)
 
 // Explanation:
 // --------------------------------
@@ -28,4 +28,4 @@ unique_id = $(display_name)
 // com.Jonas.LoopFollow
 
 // Note: Remember to comment out or remove the 'display_name' and 'unique_id' lines
-// when you want to revert to using the default bundle identifier with just the 'unique_id'.    
+// when you want to revert to using the default bundle identifier with just the 'unique_id'.

--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -8,3 +8,24 @@
 //  Copyright © 2018 Perceptus.org. All rights reserved.
 //
 unique_id = ${DEVELOPMENT_TEAM}
+
+
+// To build multiple instances of LoopFollow, uncomment the next two lines
+// and replace "Bob" with the desired app name for this instance:
+display_name = Bob
+unique_id = $(display_name)
+
+// Explanation:
+// --------------------------------
+// The 'unique_id' variable is used as part of the bundle identifier to distinguish
+// your app from others. By default, it is set to your DEVELOPMENT_TEAM ID.
+
+// If you need to create multiple instances of the app with different bundle identifiers,
+// you can uncomment the 'display_name' and 'unique_id' lines above. This allows you to
+// set a custom 'display_name' for the app, which will be used as part of the bundle identifier.
+
+// For example, if 'display_name' is set to "Jonas", the bundle identifier will become:
+// com.Jonas.LoopFollow
+
+// Note: Remember to comment out or remove the 'display_name' and 'unique_id' lines
+// when you want to revert to using the default bundle identifier with just the 'unique_id'.    

--- a/LoopFollow/Info.plist
+++ b/LoopFollow/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(display_name)</string>
 	<key>AppGroupIdentifier</key>
 	<string>group.com.$(unique_id).LoopFollow</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
@@ -88,6 +90,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
-<false/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request enables the customization of app names and bundle identifiers for multiple instances of LoopFollow. Currently, the bundle identifier is set using the unique_id variable, which is set to ${DEVELOPMENT_TEAM}. With this change, users can create distinct app names and bundle identifiers.

To use a custom app name and bundle identifier, remove the // comments on the following two lines in Config.xcconfig:
//display_name = Bob
//unique_id = $(display_name)

Replace "Bob" with the desired app name for the instance. For example, setting display_name to "Jonas" will result in a LoopFollow app named Jonas and a bundle identifier of com.Jonas.LoopFollow.

LoopFollow/Info.plist is updated to use the custom display_name in the CFBundleDisplayName. If this value is not set, the app name will default to LoopFollow.
