### PR TITLE
Filter out values above 600

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -335,9 +335,9 @@ extension MainViewController {
             if dateString >= dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) {
                 let sgvValue = data[data.count - 1 - i].sgv
                 
-                // Skip the current iteration if the sgv value is over 3000
+                // Skip the current iteration if the sgv value is over 600
                 // First time a user starts a G7, they get a value of 4000
-                if sgvValue > 3000 {
+                if sgvValue > 600 {
                     continue
                 }
                 
@@ -581,8 +581,12 @@ extension MainViewController {
                             var i = 0
                             while i <= toLoad {
                                 if i < prediction.count {
-                                    let prediction = ShareGlucoseData(sgv: Int(round(prediction[i])), date: predictionTime, direction: "flat")
-                                    predictionData.append(prediction)
+                                    let sgvValue = Int(round(prediction[i]))
+                                    // Skip values higher than 600
+                                    if sgvValue <= 600 {
+                                        let prediction = ShareGlucoseData(sgv: sgvValue, date: predictionTime, direction: "flat")
+                                        predictionData.append(prediction)
+                                    }
                                     predictionTime += 300
                                 }
                                 i += 1

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -330,13 +330,20 @@ extension MainViewController {
         }
         
         // loop through the data so we can reverse the order to oldest first for the graph
-        for i in 0..<data.count{
+        for i in 0..<data.count {
             let dateString = data[data.count - 1 - i].date
             if dateString >= dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) {
-                let reading = ShareGlucoseData(sgv: data[data.count - 1 - i].sgv, date: dateString, direction: data[data.count - 1 - i].direction)
+                let sgvValue = data[data.count - 1 - i].sgv
+                
+                // Skip the current iteration if the sgv value is over 3000
+                // First time a user starts a G7, they get a value of 4000
+                if sgvValue > 3000 {
+                    continue
+                }
+                
+                let reading = ShareGlucoseData(sgv: sgvValue, date: dateString, direction: data[data.count - 1 - i].direction)
                 bgData.append(reading)
             }
-            
         }
 
         viewUpdateNSBG(sourceName: sourceName)


### PR DESCRIPTION
A fix for the issue where user get a 4000 value that messes up the graph and statistics when starting a G7 the first time.