### PR TITLE
Preparation for ios17 calendar access

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3F1335F351590E573D8E6962 /* Pods_LoopFollow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7D55B42A22051DAD69E89D0 /* Pods_LoopFollow.framework */; };
 		DD07B5C929E2F9C400C6A635 /* NightscoutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */; };
 		DD152D3B24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD152D3A24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift */; };
+		DD7FFAFD2A72953000C3A304 /* EKEventStore+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */; };
 		DD98F54424BCEFEE0007425A /* ShareClientExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */; };
 		DDCF979424C0D380002C9752 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979324C0D380002C9752 /* UIViewExtension.swift */; };
 		DDCF979624C1443C002C9752 /* GeneralSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979524C1443C002C9752 /* GeneralSettingsViewController.swift */; };
@@ -177,6 +178,7 @@
 		A7D55B42A22051DAD69E89D0 /* Pods_LoopFollow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LoopFollow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUtils.swift; sourceTree = "<group>"; };
 		DD152D3A24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoDisplaySettingsViewController.swift; sourceTree = "<group>"; };
+		DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Extensions.swift"; sourceTree = "<group>"; };
 		DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareClientExtension.swift; sourceTree = "<group>"; };
 		DDCF979324C0D380002C9752 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		DDCF979524C1443C002C9752 /* GeneralSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsViewController.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */,
 				DDCF979324C0D380002C9752 /* UIViewExtension.swift */,
 				FC1BB3A7252CA4C5003839C2 /* UIImageExtension.swift */,
+				DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -862,6 +865,7 @@
 			files = (
 				FCC68850248935D800A0279D /* AlarmViewController.swift in Sources */,
 				FC7CE59F248D8D23001F83B8 /* SnoozeViewController.swift in Sources */,
+				DD7FFAFD2A72953000C3A304 /* EKEventStore+Extensions.swift in Sources */,
 				FCC6886724898F8000A0279D /* UserDefaultsValue.swift in Sources */,
 				DDCF979E24C2382A002C9752 /* AppStateController.swift in Sources */,
 				FC97881E2485969B00A7906C /* NightScoutViewController.swift in Sources */,

--- a/LoopFollow/Application/AppDelegate.swift
+++ b/LoopFollow/Application/AppDelegate.swift
@@ -28,9 +28,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print("User has declined notifications")
             }
         }
+        
         let store = EKEventStore()
-        store.requestAccess(to: .event) {(granted, error) in
-           if !granted { return }
+        store.requestCalendarAccess { (granted, error) in
+            if !granted {
+                print("Failed to get calendar access: \(String(describing: error))")
+                return
+            }
         }
         
         UNUserNotificationCenter.current().delegate = self

--- a/LoopFollow/Extensions/EKEventStore+Extensions.swift
+++ b/LoopFollow/Extensions/EKEventStore+Extensions.swift
@@ -1,0 +1,34 @@
+//
+//  EKEventStore+Extensions.swift
+//  LoopFollow
+//
+//  Created by Jonas Björkert on 2023-07-27.
+//  Copyright © 2023 Jon Fawcett. All rights reserved.
+//
+
+import Foundation
+import EventKit
+
+#if swift(>=5.9)
+extension EKEventStore {
+    func requestCalendarAccess(completion: @escaping (Bool, Error?) -> Void) {
+        if #available(iOS 17, *) {
+            requestFullAccessToEvents { (granted, error) in
+                completion(granted, error)
+            }
+        } else {
+            requestAccess(to: .event) { (granted, error) in
+                completion(granted, error)
+            }
+        }
+    }
+}
+#else
+extension EKEventStore {
+    func requestCalendarAccess(completion: @escaping (Bool, Error?) -> Void) {
+        requestAccess(to: .event) { (granted, error) in
+            completion(granted, error)
+        }
+    }
+}
+#endif

--- a/LoopFollow/Info.plist
+++ b/LoopFollow/Info.plist
@@ -87,7 +87,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Loop Follow would like to access your calendar to update BG readings</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-<false/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
This will build with lower versions of xcode since there is a compile time swift version check

Calendar access control is moved centrally to an extension

If the app is missing access, this is now displayed in the apple watch/calendar menu

Calendar access is changed to follow: https://developer.apple.com/documentation/technotes/tn3152-migrating-to-the-latest-calendar-access-levels