### PR TITLE
Add "loopfollow" CFBundleURLSchemes

### DIFF
--- a/LoopFollow/Info.plist
+++ b/LoopFollow/Info.plist
@@ -89,6 +89,15 @@
 	</array>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Loop Follow would like to access your calendar to update BG readings</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>loopfollow</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
This allows to open Loop Follow via the url loopfollow://

This can be handy for instance if using Scriptable to make a widget on the iPhone lockscreen or elsewhere.

To enable this, select
"When interacting" = Open URL
"URL" = loopfollow://
