### PR TITLE
Sage>10days

### DIFF
--- a/LoopFollow/Controllers/Nightscout/SAge.swift
+++ b/LoopFollow/Controllers/Nightscout/SAge.swift
@@ -10,7 +10,7 @@ import Foundation
 extension MainViewController {
     // NS Sage Web Call
     func webLoadNSSage() {
-        let lastDateString = dateTimeUtils.nowMinus10DaysTimeInterval()
+        let lastDateString = dateTimeUtils.nowMinus60DaysTimeInterval()
         let currentTimeString = dateTimeUtils.getCurrentDateTimeString()
         
         let parameters: [String: String] = [

--- a/LoopFollow/helpers/DateTime.swift
+++ b/LoopFollow/helpers/DateTime.swift
@@ -82,7 +82,7 @@ class dateTimeUtils {
         return nHoursAgoString
     }
     
-    static func nowMinus10DaysTimeInterval() -> String {
+    static func nowMinus60DaysTimeInterval() -> String {
         let today = Date()
         let oldDate = Calendar.current.date(byAdding: .day, value: -10, to: today)!
         let dateFormatter = DateFormatter()


### PR DESCRIPTION
LoopFollow does not display SAGE values of more than 10 days. That was fine when everyone was using factory G6 transmitters, which cut the session at ten days sharp. Today, many are using Anubis transmitters which allow (theoretically) running sensors up to 60 days. 

This PR changes the ten day limit into a sixty days limit. 

I have not changed anything related to Sensor change reminders, which still assume ten days is the max, and allows alerts  to be set a user defined number of hours before the ten day limit. In my view, this is fine. 