### PR TITLE
fix for override without duration

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1969,7 +1969,9 @@ extension MainViewController {
             }
             var duration: Double = 5.0
             if let durationType = currentEntry?["durationType"] as? String {
-                duration = dateTimeUtils.getNowTimeIntervalUTC() - dateTimeStamp + (60 * 60)
+                if i == entries.count - 1 {
+                    duration = dateTimeUtils.getNowTimeIntervalUTC() - dateTimeStamp + (60 * 60)
+                }
             } else {
                 duration = (currentEntry?["duration"] as? Double)!
                 duration = duration * 60


### PR DESCRIPTION
<img width="1306" alt="CleanShot 2023-10-01 at 21 08 20@2x" src="https://github.com/loopandlearn/LoopFollow/assets/12718238/2100d9f3-19b2-4377-bae1-f461ac06c910">

Only the last override is allowed to run without a duration.