### PR TITLE
Sync the GitHub runner clock with the Windows time server

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -24,6 +24,10 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
         
       # Create or update identifiers for app
       - name: Fastlane Provision

--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -35,6 +35,10 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
       
       # Build signed Loop Follow IPA file
       - name: Fastlane Build & Archive

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -25,6 +25,10 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
         
       # Create or update certificates for app
       - name: Create Certificates

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -124,6 +124,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
         
       - name: Validate Fastlane Secrets
         run: |


### PR DESCRIPTION
Adding a step to workflow jobs that interface Apple servers, as a workaround for build issues caused by runner clocks being out of sync. See https://github.com/actions/runner issue number 2996 for details.

name: Sync clock
run: sudo sntp -sS time.windows.com
Added to the following workflows / jobs:

validate_secrets.yml / validate-fastlane-secrets
add_identifiers.yml / identifiers
build_LoopFollow.yml / build
create_certs.yml / certificates
