### PR TITLE
Implement Dynamic Server Text Update & Add 'Show App Name' Setting

### DIFF
--- a/LoopFollow/Controllers/AppStateController.swift
+++ b/LoopFollow/Controllers/AppStateController.swift
@@ -49,7 +49,7 @@ enum GeneralSettingsChangeEnum: Int {
     case showStatsChange = 1024
     case showSmallGraphChange = 2048
     case useIFCCChange = 4096
-    case showAppNameChange = 8192
+    case showDisplayNameChange = 8192
 }
 
 class AppStateController {

--- a/LoopFollow/Controllers/AppStateController.swift
+++ b/LoopFollow/Controllers/AppStateController.swift
@@ -36,19 +36,20 @@ enum ChartSettingsChangeEnum: Int {
 
 // General Settings Flags
 enum GeneralSettingsChangeEnum: Int { 
-   case colorBGTextChange = 1
-   case speakBGChange = 2
-   case backgroundRefreshFrequencyChange = 4
-   case backgroundRefreshChange = 8
-   case appBadgeChange = 16
-   case dimScreenWhenIdleChange = 32
-   case forceDarkModeChang = 64
-   case persistentNotificationChange = 128
-   case persistentNotificationLastBGTimeChange = 256
-   case screenlockSwitchStateChange = 512
+    case colorBGTextChange = 1
+    case speakBGChange = 2
+    case backgroundRefreshFrequencyChange = 4
+    case backgroundRefreshChange = 8
+    case appBadgeChange = 16
+    case dimScreenWhenIdleChange = 32
+    case forceDarkModeChang = 64
+    case persistentNotificationChange = 128
+    case persistentNotificationLastBGTimeChange = 256
+    case screenlockSwitchStateChange = 512
     case showStatsChange = 1024
     case showSmallGraphChange = 2048
     case useIFCCChange = 4096
+    case showAppNameChange = 8192
 }
 
 class AppStateController {

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -205,7 +205,7 @@ extension MainViewController {
     }
     
     func updateServerText(with serverText: String? = nil) {
-        if UserDefaultsRepository.showAppName.value, let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
+        if UserDefaultsRepository.showDisplayName.value, let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
             self.serverText.text = displayName
         } else if let serverText = serverText {
             self.serverText.text = serverText

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -204,6 +204,14 @@ extension MainViewController {
         viewUpdateNSBG(sourceName: sourceName)
     }
     
+    func updateServerText(with serverText: String? = nil) {
+        if UserDefaultsRepository.showAppName.value, let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
+            self.serverText.text = displayName
+        } else if let serverText = serverText {
+            self.serverText.text = serverText
+        }
+    }
+    
     // NS BG Data Front end updater
     func viewUpdateNSBG (sourceName: String) {
         DispatchQueue.main.async {
@@ -229,7 +237,7 @@ extension MainViewController {
                 userUnit = " mmol/L"
             }
             
-            self.serverText.text = sourceName
+            self.updateServerText(with: sourceName)
             
             var snoozerBG = ""
             var snoozerDirection = ""

--- a/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
@@ -151,7 +151,20 @@ class GeneralSettingsViewController: FormViewController {
                     NotificationCenter.default.post(name: Notification.Name("toggleSpeakBG"), object: nil)
         }
         
-        +++ ButtonRow() {
+       <<< SwitchRow("showAppName") { row in
+           row.title = "Show App Name"
+           row.value = UserDefaultsRepository.showAppName.value
+       }.onChange { [weak self] row in
+           guard let value = row.value else { return }
+           UserDefaultsRepository.showAppName.value = value
+
+           if let appState = self!.appStateController {
+               appState.generalSettingsChanged = true
+               appState.generalSettingsChanges |= GeneralSettingsChangeEnum.showAppNameChange.rawValue
+           }
+       }
+
+       +++ ButtonRow() {
           $0.title = "DONE"
        }.onCellSelection { (row, arg)  in
           self.dismiss(animated:true, completion: nil)

--- a/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
@@ -151,16 +151,16 @@ class GeneralSettingsViewController: FormViewController {
                     NotificationCenter.default.post(name: Notification.Name("toggleSpeakBG"), object: nil)
         }
         
-       <<< SwitchRow("showAppName") { row in
-           row.title = "Show App Name"
-           row.value = UserDefaultsRepository.showAppName.value
+       <<< SwitchRow("showDisplayName") { row in
+           row.title = "Show Display Name"
+           row.value = UserDefaultsRepository.showDisplayName.value
        }.onChange { [weak self] row in
            guard let value = row.value else { return }
-           UserDefaultsRepository.showAppName.value = value
+           UserDefaultsRepository.showDisplayName.value = value
 
            if let appState = self!.appStateController {
                appState.generalSettingsChanged = true
-               appState.generalSettingsChanges |= GeneralSettingsChangeEnum.showAppNameChange.rawValue
+               appState.generalSettingsChanges |= GeneralSettingsChangeEnum.showDisplayNameChange.rawValue
            }
        }
 

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -296,61 +296,65 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         // check the app state
         // TODO: move to a function ?
         if let appState = self.appStateController {
-        
-           if appState.chartSettingsChanged {
-              
-              // can look at settings flags to be more fine tuned
-              self.updateBGGraphSettings()
             
-            if ChartSettingsChangeEnum.smallGraphHeight.rawValue != 0 {
-                smallGraphHeightConstraint.constant = CGFloat(UserDefaultsRepository.smallGraphHeight.value)
-                self.view.layoutIfNeeded()
+            if appState.chartSettingsChanged {
+                
+                // can look at settings flags to be more fine tuned
+                self.updateBGGraphSettings()
+                
+                if ChartSettingsChangeEnum.smallGraphHeight.rawValue != 0 {
+                    smallGraphHeightConstraint.constant = CGFloat(UserDefaultsRepository.smallGraphHeight.value)
+                    self.view.layoutIfNeeded()
+                }
+                
+                // reset the app state
+                appState.chartSettingsChanged = false
+                appState.chartSettingsChanges = 0
             }
-              
-              // reset the app state
-              appState.chartSettingsChanged = false
-              appState.chartSettingsChanges = 0
-           }
-           if appState.generalSettingsChanged {
-           
-              // settings for appBadge changed
-              if appState.generalSettingsChanges & GeneralSettingsChangeEnum.appBadgeChange.rawValue != 0 {
-                 
-              }
-              
-              // settings for textcolor changed
-              if appState.generalSettingsChanges & GeneralSettingsChangeEnum.colorBGTextChange.rawValue != 0 {
-                 self.setBGTextColor()
-              }
+            if appState.generalSettingsChanged {
+                
+                // settings for appBadge changed
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.appBadgeChange.rawValue != 0 {
+                    
+                }
+                
+                // settings for textcolor changed
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.colorBGTextChange.rawValue != 0 {
+                    self.setBGTextColor()
+                }
+                
+                // settings for showStats changed
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showStatsChange.rawValue != 0 {
+                    statsView.isHidden = !UserDefaultsRepository.showStats.value
+                }
+                
+                // settings for useIFCC changed
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.useIFCCChange.rawValue != 0 {
+                    updateStats()
+                }
+                
+                // settings for showSmallGraph changed
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showSmallGraphChange.rawValue != 0 {
+                    BGChartFull.isHidden = !UserDefaultsRepository.showSmallGraph.value
+                }
+                
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showAppNameChange.rawValue != 0 {
+                    self.updateServerText()
+                }
+                
+                // reset the app state
+                appState.generalSettingsChanged = false
+                appState.generalSettingsChanges = 0
+            }
+            if appState.infoDataSettingsChanged {
+                createDerivedData()
+                self.infoTable.reloadData()
+                
+                // reset
+                appState.infoDataSettingsChanged = false
+            }
             
-            // settings for showStats changed
-            if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showStatsChange.rawValue != 0 {
-               statsView.isHidden = !UserDefaultsRepository.showStats.value
-            }
-
-            // settings for useIFCC changed
-            if appState.generalSettingsChanges & GeneralSettingsChangeEnum.useIFCCChange.rawValue != 0 {
-                updateStats()
-            }
-
-            // settings for showSmallGraph changed
-            if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showSmallGraphChange.rawValue != 0 {
-                BGChartFull.isHidden = !UserDefaultsRepository.showSmallGraph.value
-            }
-              
-              // reset the app state
-              appState.generalSettingsChanged = false
-              appState.generalSettingsChanges = 0
-           }
-           if appState.infoDataSettingsChanged {
-              createDerivedData()
-              self.infoTable.reloadData()
-              
-              // reset
-              appState.infoDataSettingsChanged = false
-           }
-           
-           // add more processing of the app state
+            // add more processing of the app state
         }
     }
     

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -338,7 +338,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
                     BGChartFull.isHidden = !UserDefaultsRepository.showSmallGraph.value
                 }
                 
-                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showAppNameChange.rawValue != 0 {
+                if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showDisplayNameChange.rawValue != 0 {
                     self.updateServerText()
                 }
                 

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -75,7 +75,7 @@ class UserDefaultsRepository {
     static let useIFCC = UserDefaultsValue<Bool>(key: "useIFCC", default: false)
     static let showSmallGraph = UserDefaultsValue<Bool>(key: "showSmallGraph", default: true)
     static let speakBG = UserDefaultsValue<Bool>(key: "speakBG", default: false)
-    static let showAppName = UserDefaultsValue<Bool>(key: "showAppName", default: false)
+    static let showDisplayName = UserDefaultsValue<Bool>(key: "showDisplayName", default: false)
     static let backgroundRefreshFrequency = UserDefaultsValue<Double>(key: "backgroundRefreshFrequency", default: 1)
     static let backgroundRefresh = UserDefaultsValue<Bool>(key: "backgroundRefresh", default: true)
     static let appBadge = UserDefaultsValue<Bool>(key: "appBadge", default: true)

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -75,6 +75,7 @@ class UserDefaultsRepository {
     static let useIFCC = UserDefaultsValue<Bool>(key: "useIFCC", default: false)
     static let showSmallGraph = UserDefaultsValue<Bool>(key: "showSmallGraph", default: true)
     static let speakBG = UserDefaultsValue<Bool>(key: "speakBG", default: false)
+    static let showAppName = UserDefaultsValue<Bool>(key: "showAppName", default: false)
     static let backgroundRefreshFrequency = UserDefaultsValue<Double>(key: "backgroundRefreshFrequency", default: 1)
     static let backgroundRefresh = UserDefaultsValue<Bool>(key: "backgroundRefresh", default: true)
     static let appBadge = UserDefaultsValue<Bool>(key: "appBadge", default: true)


### PR DESCRIPTION
This pull request introduces a new feature that dynamically updates the server text based on user preferences. Key changes include:

New Functionality:
Added updateServerText function in BGData.swift for dynamic text updates in the main view controller.

User Setting Integration:
Integrated a new user setting showAppName in GeneralSettingsViewController.swift and UserDefaults.swift for toggling the display of the app's name.

Enum Extension:
Extended GeneralSettingsChangeEnum in AppStateController.swift to include showAppNameChange.

UI and Logic Updates:
Updated MainViewController.swift to use the new updateServerText function and handle the showAppNameChange setting.

Immediate Effect of Toggle:
If showAppName is toggled on, it will be immediately reflected in the GUI. When toggled off, Nightscout or Dexcom will be shown as the server text after the next BG update, depending on the source used.

These changes enhance the user experience by allowing the display of the app name based on user preference and streamline the server text update process. The immediate effect of the toggle provides a responsive interface for the users.