### PR TITLE
Disable Auto-Capitalization in Text Fields of SettingsViewController

### DIFF
--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -78,6 +78,7 @@ class SettingsViewController: FormViewController {
            row.hidden = "$showNS == false"
        }.cellSetup { (cell, row) in
            cell.textField.autocorrectionType = .no
+           cell.textField.autocapitalizationType = .none
        }.onChange { row in
            guard let value = row.value else {
                UserDefaultsRepository.url.value = ""
@@ -104,6 +105,7 @@ class SettingsViewController: FormViewController {
            row.hidden = "$showNS == false"
        }.cellSetup { (cell, row) in
            cell.textField.autocorrectionType = .no
+           cell.textField.autocapitalizationType = .none
        }.onChange { row in
            if row.value == nil {
                UserDefaultsRepository.token.value = ""
@@ -144,6 +146,7 @@ class SettingsViewController: FormViewController {
             row.hidden = "$showDex == false"
         }.cellSetup { (cell, row) in
             cell.textField.autocorrectionType = .no
+            cell.textField.autocapitalizationType = .none
         }.onChange { row in
             if row.value == nil {
                 UserDefaultsRepository.shareUserName.value = ""
@@ -159,6 +162,7 @@ class SettingsViewController: FormViewController {
         }.cellSetup { (cell, row) in
             cell.textField.autocorrectionType = .no
             cell.textField.isSecureTextEntry = true
+            cell.textField.autocapitalizationType = .none
         }.onChange { row in
             if row.value == nil {
                 UserDefaultsRepository.sharePassword.value = ""


### PR DESCRIPTION
This update involves setting autocapitalizationType to .none for each text field, thereby disabling automatic capitalization when a user starts typing. The change is aimed at improving user input experience, especially for fields where automatic capitalization is not necessary or could be problematic, like URLs, tokens, usernames, and passwords. The change is systematically applied in the .cellSetup closure for multiple text fields, complementing the existing autocorrectionType = .no setting.