### PR TITLE
Add function to clear web cache (Nightscout) when refreshing view by swiping down

### DIFF
--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -64,11 +64,12 @@ class NightscoutViewController: UIViewController {
     // New code to clear web cache
     func clearWebCache() {
         let dataStore = WKWebsiteDataStore.default()
+        let cacheTypes = Set([WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache])
         let date = Date(timeIntervalSince1970: 0)
-        dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: date) {
-            print("Web cache cleared.")
+        dataStore.removeData(ofTypes: cacheTypes, modifiedSince: date) {
+          print(“Web cache cleared.“)
         }
-    }
+      }
     
     // this handles target=_blank links by opening them in the same view
     func webView(webView: WKWebView!, createWebViewWithConfiguration configuration: WKWebViewConfiguration!, forNavigationAction navigationAction: WKNavigationAction!, windowFeatures: WKWindowFeatures!) -> WKWebView! {

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -67,7 +67,7 @@ class NightscoutViewController: UIViewController {
         let cacheTypes = Set([WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache])
         let date = Date(timeIntervalSince1970: 0)
         dataStore.removeData(ofTypes: cacheTypes, modifiedSince: date) {
-          print(“Web cache cleared.“)
+          print("Web cache cleared.")
         }
       }
     

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -45,20 +45,9 @@ class NightscoutViewController: UIViewController {
     }
     
     @objc func reloadWebView(_ sender: UIRefreshControl) {
-        let alertController = UIAlertController(title: "Clear Web Cache", message: "Do you want to clear the web cache?\nNote: All Nightscout settings will be reverted to defaults!", preferredStyle: .alert)
-        
-        alertController.addAction(UIAlertAction(title: "Yes", style: .destructive) { _ in
-            self.clearWebCache()
-            self.webView.reload()
-            sender.endRefreshing()
-        })
-        
-        alertController.addAction(UIAlertAction(title: "No", style: .cancel) { _ in
-            self.webView.reload()
-            sender.endRefreshing()
-        })
-        
-        present(alertController, animated: true, completion: nil)
+        self.clearWebCache()
+        self.webView.reload()
+        sender.endRefreshing()
     }
     
     // New code to clear web cache

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -45,12 +45,23 @@ class NightscoutViewController: UIViewController {
     }
     
     @objc func reloadWebView(_ sender: UIRefreshControl) {
-        clearWebCache() // Clear web cache when reloading page by swiping down
-        webView.reload()
-        sender.endRefreshing()
+        let alertController = UIAlertController(title: "Clear Web Cache", message: "Do you want to clear the web cache?\nNote: All Nightscout settings will be reverted to defaults!", preferredStyle: .alert)
+        
+        alertController.addAction(UIAlertAction(title: "Yes", style: .destructive) { _ in
+            self.clearWebCache()
+            self.webView.reload()
+            sender.endRefreshing()
+        })
+        
+        alertController.addAction(UIAlertAction(title: "No", style: .cancel) { _ in
+            self.webView.reload()
+            sender.endRefreshing()
+        })
+        
+        present(alertController, animated: true, completion: nil)
     }
     
-    // New code to Clear web cache
+    // New code to clear web cache
     func clearWebCache() {
         let dataStore = WKWebsiteDataStore.default()
         let date = Date(timeIntervalSince1970: 0)

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -43,10 +43,20 @@ class NightscoutViewController: UIViewController {
         
         self.webView.uiDelegate = self
     }
-
+    
     @objc func reloadWebView(_ sender: UIRefreshControl) {
+        clearWebCache() // Clear web cache when reloading page by swiping down
         webView.reload()
         sender.endRefreshing()
+    }
+    
+    // New code to Clear web cache
+    func clearWebCache() {
+        let dataStore = WKWebsiteDataStore.default()
+        let date = Date(timeIntervalSince1970: 0)
+        dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: date) {
+            print("Web cache cleared.")
+        }
     }
     
     // this handles target=_blank links by opening them in the same view


### PR DESCRIPTION
**Issue**
When applying any kind of code changes in Nightscout, the web cache in Loop Follow tends to keep the old version in cache for a long time. 

There is currently no easy way to clear the web cache to make changes in nightscout visible immediately (other than to delete and reinstall Loop Follow, or wait for an extended period of time (weeks?) until the cache clears automatically)

The everyday user of LF probably dont have any needs to frequently clear the web cache, but for developers and other "super users" the inability to clear the web cache are more troublesome.

**Suggested solution**
This PR introduces an easy way to clear the nightscout web cache by extending the current function reloadWebView to also clear web cache when swiping down.

One potential UX issue with clearing the cache is that all Nightscout settings are reverted to defaults in config vars (ie any changes of settings in the LF Nightscout browser instance gets overridden when clearing the cache). 

To adress this issue an alert _"Do you want to clear the web cache?\nNote: All Nightscout settings will be reverted to defaults!"_ is presented and the user can select yes to continue with clearing the cache, or no to just reload the web view (as current app behavior before this PR).

The PR has been tested in Xcode simulator and on a running iPhone 13, and is behaving as expected.

See attached screen recording for look n feel demo.

https://github.com/loopandlearn/LoopFollow/assets/72826201/245dbc6d-a4e5-4562-8952-c6daab2c3c05



