### PR TITLE
Implement User-Initiated Scroll Detection to Control Chart Auto-Scrolling

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -527,7 +527,10 @@ extension MainViewController {
         }
         
         // Move to current reading everytime new readings load
-        BGChart.moveViewToAnimated(xValue: dateTimeUtils.getNowTimeIntervalUTC() - (BGChart.visibleXRange * 0.7), yValue: 0.0, axis: .right, duration: 1, easingOption: .easeInBack)
+        // Check if auto-scrolling should be performed
+        if autoScrollPauseUntil == nil || Date() > autoScrollPauseUntil! {
+            BGChart.moveViewToAnimated(xValue: dateTimeUtils.getNowTimeIntervalUTC() - (BGChart.visibleXRange * 0.7), yValue: 0.0, axis: .right, duration: 1, easingOption: .easeInBack)
+        }
     }
     
     func updatePredictionGraph(color: UIColor? = nil) {

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -148,6 +148,8 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     // This is a temporary safeguard until the issue with multiple calls to speakBG is fixed.
     var lastSpeechTime: Date?
 
+    var autoScrollPauseUntil: Date? = nil
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -824,6 +826,13 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         
     }
     
-    
+    // User has scrolled the chart
+    func chartTranslated(_ chartView: ChartViewBase, dX: CGFloat, dY: CGFloat) {
+        let isViewingLatestData = abs(BGChart.highestVisibleX - BGChart.chartXMax) < 0.001
+        if isViewingLatestData {
+            autoScrollPauseUntil = nil // User is back at the latest data, allow auto-scrolling
+        } else {
+            autoScrollPauseUntil = Date().addingTimeInterval(5 * 60) // User is viewing historical data, pause auto-scrolling
+        }
+    }
 }
-


### PR DESCRIPTION
## Overview
This PR introduces enhancements to the blood glucose chart's auto-scrolling behavior in the `MainViewController`. The primary goal is to improve the user experience by allowing manual chart interactions (like scrolling to view historical data) without being interrupted by auto-scrolling to the latest data point. 

## Changes
- Added a `Date?` variable named `autoScrollPauseUntil` to `MainViewController`. This variable tracks the time until which auto-scrolling should be paused due to user interaction.
- Modified the `updateBGGraph` method to check `autoScrollPauseUntil` before executing auto-scrolling logic. Auto-scrolling now only occurs if `autoScrollPauseUntil` is `nil` or the current time is past the `autoScrollPauseUntil` timestamp.
- Implemented the `chartTranslated` delegate method to update `autoScrollPauseUntil` based on user scrolling. If the user scrolls to the latest data point, `autoScrollPauseUntil` is set to `nil`, allowing immediate resumption of auto-scrolling. If the user scrolls to view historical data, `autoScrollPauseUntil` is set to 5 minutes into the future, temporarily pausing auto-scrolling.

## Rationale
The motivation behind these changes is to strike a balance between keeping users informed of the latest blood glucose data and allowing uninterrupted exploration of historical data. By intelligently managing auto-scrolling based on user interaction, we enhance the application's usability, particularly for users who actively engage with their historical blood glucose data.

## Testing
These changes have been tested in the development environment to ensure that:
- Auto-scrolling is paused for 5 minutes when the user manually scrolls the chart.
- Auto-scrolling resumes immediately when the user scrolls back to the latest data point or after 5 minutes of inactivity post-scroll.
- The overall functionality and performance of the chart remain unaffected by these updates.