### PR TITLE
Testflight build expiration

### DIFF
--- a/BuildDetails.plist
+++ b/BuildDetails.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		DD7E198A2ACDA62600DBD158 /* SensorStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E19892ACDA62600DBD158 /* SensorStart.swift */; };
 		DD7FFAFD2A72953000C3A304 /* EKEventStore+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */; };
 		DD98F54424BCEFEE0007425A /* ShareClientExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */; };
+		DDB0AF522BB1A8BE00AFA48B /* BuildDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */; };
+		DDB0AF552BB1B24A00AFA48B /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = DDB0AF542BB1B24A00AFA48B /* BuildDetails.plist */; };
 		DDCF979424C0D380002C9752 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979324C0D380002C9752 /* UIViewExtension.swift */; };
 		DDCF979624C1443C002C9752 /* GeneralSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979524C1443C002C9752 /* GeneralSettingsViewController.swift */; };
 		DDCF979824C1489C002C9752 /* GraphSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979724C1489C002C9752 /* GraphSettingsViewController.swift */; };
@@ -212,6 +214,9 @@
 		DD7E19892ACDA62600DBD158 /* SensorStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorStart.swift; sourceTree = "<group>"; };
 		DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Extensions.swift"; sourceTree = "<group>"; };
 		DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareClientExtension.swift; sourceTree = "<group>"; };
+		DDB0AF502BB1A84500AFA48B /* capture-build-details.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "capture-build-details.sh"; sourceTree = "<group>"; };
+		DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildDetails.swift; sourceTree = "<group>"; };
+		DDB0AF542BB1B24A00AFA48B /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BuildDetails.plist; sourceTree = "<group>"; };
 		DDCF979324C0D380002C9752 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		DDCF979524C1443C002C9752 /* GeneralSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsViewController.swift; sourceTree = "<group>"; };
 		DDCF979724C1489C002C9752 /* GraphSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphSettingsViewController.swift; sourceTree = "<group>"; };
@@ -454,6 +459,14 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		DDB0AF4F2BB1A81F00AFA48B /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				DDB0AF502BB1A84500AFA48B /* capture-build-details.sh */,
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
 		FC16A97624995FEE003D6245 /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -632,6 +645,8 @@
 		FC97880B2485969B00A7906C = {
 			isa = PBXGroup;
 			children = (
+				DDB0AF542BB1B24A00AFA48B /* BuildDetails.plist */,
+				DDB0AF4F2BB1A81F00AFA48B /* Scripts */,
 				DDCFCAF12B17273200BE5751 /* LoopFollowDisplayNameConfig.xcconfig */,
 				FC3AE7B3249E8E0E00AAE1E0 /* LoopFollow.xcdatamodeld */,
 				FC5A5C3C2497B229009C550E /* Config.xcconfig */,
@@ -676,6 +691,7 @@
 				FCD2A27C24C9D044009F7B7B /* Globals.swift */,
 				FC8589BE252B54F500C8FC73 /* Mobileprovision.swift */,
 				DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */,
+				DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */,
 			);
 			path = helpers;
 			sourceTree = "<group>";
@@ -710,6 +726,7 @@
 				FC9788112485969B00A7906C /* Frameworks */,
 				FC9788122485969B00A7906C /* Resources */,
 				04DA71CCA0280FA5FA2DF7A6 /* [CP] Embed Pods Frameworks */,
+				DDB0AF532BB1AA0900AFA48B /* Capture Build Details */,
 			);
 			buildRules = (
 			);
@@ -786,6 +803,7 @@
 				FC7CE53F248ABE37001F83B8 /* Siri_Alert_Glucose_Dropping_Fast.caf in Resources */,
 				FC7CE561248ABE37001F83B8 /* Wrong_Answer.caf in Resources */,
 				FCC6885C2489559400A0279D /* blank.wav in Resources */,
+				DDB0AF552BB1B24A00AFA48B /* BuildDetails.plist in Resources */,
 				FC7CE528248ABE37001F83B8 /* Cartoon_Bounce_To_Ceiling.caf in Resources */,
 				FC7CE57B248ABE37001F83B8 /* Alert_Tone_Busy.caf in Resources */,
 				FC7CE51B248ABE37001F83B8 /* Thunder_Sound_FX.caf in Resources */,
@@ -924,6 +942,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		DDB0AF532BB1AA0900AFA48B /* Capture Build Details */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Capture Build Details";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/capture-build-details.sh\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -947,6 +983,7 @@
 				DD7E19862ACDA59700DBD158 /* BGCheck.swift in Sources */,
 				FC16A97D24996747003D6245 /* Alarms.swift in Sources */,
 				FC16A97B249966A3003D6245 /* AlarmSound.swift in Sources */,
+				DDB0AF522BB1A8BE00AFA48B /* BuildDetails.swift in Sources */,
 				DD493AE72ACF23CF009A6922 /* DeviceStatus.swift in Sources */,
 				FCFEECA2248857A600402A7F /* SettingsViewController.swift in Sources */,
 				FCFEECA02488157B00402A7F /* Chart.swift in Sources */,

--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -94,6 +94,10 @@ class SettingsViewController: FormViewController {
        UserDefaultsRepository.showDex.value = false
     
        let expiration = calculateExpirationDate()
+       var expirationHeaderString = "App Expiration"
+       if isTestFlightBuild() {
+          expirationHeaderString = "Beta (TestFlight) Expiration"
+       }
                         
         form
         +++ Section(header: "Data Settings", footer: "")
@@ -295,7 +299,7 @@ class SettingsViewController: FormViewController {
 
        +++ Section(header: getAppVersion(), footer: "")
 
-       +++ Section(header: "App Expiration", footer: String(expiration.description))
+       +++ Section(header: expirationHeaderString, footer: String(expiration.description))
 
         showHideNSDetails()
        checkNightscoutStatus()

--- a/LoopFollow/helpers/BuildDetails.swift
+++ b/LoopFollow/helpers/BuildDetails.swift
@@ -24,6 +24,6 @@ class BuildDetails {
     }
     
     var buildDateString: String? {
-        return dict["com-loopkit-Loop-build-date"] as? String
+        return dict["com-LoopFollow-date"] as? String
     }
 }

--- a/LoopFollow/helpers/BuildDetails.swift
+++ b/LoopFollow/helpers/BuildDetails.swift
@@ -1,0 +1,29 @@
+//
+//  BuildDetails.swift
+//  LoopFollow
+//
+//  Created by Jonas Björkert on 2024-03-25.
+//  Copyright © 2024 Jon Fawcett. All rights reserved.
+//
+
+import Foundation
+
+class BuildDetails {
+    static var `default` = BuildDetails()
+    
+    let dict: [String: Any]
+    
+    init() {
+        guard let url = Bundle.main.url(forResource: "BuildDetails", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let parsed = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            dict = [:]
+            return
+        }
+        dict = parsed
+    }
+    
+    var buildDateString: String? {
+        return dict["com-loopkit-Loop-build-date"] as? String
+    }
+}

--- a/LoopFollow/helpers/BuildDetails.swift
+++ b/LoopFollow/helpers/BuildDetails.swift
@@ -24,6 +24,6 @@ class BuildDetails {
     }
     
     var buildDateString: String? {
-        return dict["com-LoopFollow-date"] as? String
+        return dict["com-LoopFollow-build-date"] as? String
     }
 }

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -17,4 +17,4 @@ fi
 echo "Gathering build date..."
 
 # Capture the current date and write it to BuildDetails.plist
-plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
+plutil -replace com-LoopFollow-date -string "$(date)" "${info_plist_path}"

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -e
+
+#  capture-build-details.sh
+#  LoopFollow
+#
+#  Created by Jonas Björkert on 2024-03-25.
+#  Copyright © 2024 Jon Fawcett. All rights reserved.
+
+info_plist_path="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/BuildDetails.plist"
+
+# Ensure the path to BuildDetails.plist is valid.
+if [ "${info_plist_path}" == "/" -o ! -e "${info_plist_path}" ]; then
+  echo "ERROR: BuildDetails.plist file does not exist at path: ${info_plist_path}" >&2
+  exit 1
+fi
+
+echo "Gathering build date..."
+
+# Capture the current date and write it to BuildDetails.plist
+plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -17,4 +17,4 @@ fi
 echo "Gathering build date..."
 
 # Capture the current date and write it to BuildDetails.plist
-plutil -replace com-LoopFollow-date -string "$(date)" "${info_plist_path}"
+plutil -replace com-LoopFollow-build-date -string "$(date)" "${info_plist_path}"


### PR DESCRIPTION
## Enhance Build Information Management

### Overview

This PR introduces enhancements to how the app manages and utilizes build information, with a particular focus on distinguishing between Xcode and TestFlight builds. A key part of this enhancement is the inclusion of a manually added `BuildDetails.plist` file in the project, which stores essential build details. The PR also includes updates to the app's logic to read from this plist and calculate build expiration dates, especially for TestFlight builds, where a specific validity period is important for managing updates and functionality.

### Changes

- **Manually Added `BuildDetails.plist`**: `BuildDetails.plist` has been manually added to the project. It should be updated as needed to reflect current build details.
- **Build Expiration Logic**: The `SettingsViewController` now includes updated logic to read build details from `BuildDetails.plist` and determine the build's expiration date. This is particularly critical for TestFlight builds, which have a 90-day validity period from the build date.
- **Utility Functions**: New utility functions `isTestFlightBuild()`, `buildDate()`, and `calculateExpirationDate()` have been introduced in `SettingsViewController` to facilitate these enhancements.

### Testing

- [ ] Test the app's ability to correctly identify TestFlight builds and calculate expiration dates based on the 90-day validity period.
- [ ] Test the app's ability to correctly identify Mac Xcode builds and show expiration dates based provisioning profile.
- [ ] Confirm that the addition of `BuildDetails.plist` and the new logic in `SettingsViewController` do not adversely affect existing app functionality.

### Notes

- The 90-day expiration assumption for TestFlight builds aligns with Apple's guidelines but may require updates if those guidelines change.
