### PR TITLE
Fix date parsing issue for 12/24-hour formats

### DIFF
--- a/LoopFollow/helpers/NightscoutUtils.swift
+++ b/LoopFollow/helpers/NightscoutUtils.swift
@@ -192,10 +192,12 @@ class NightscoutUtils {
         let dateFormatterWithMilliseconds = DateFormatter()
         dateFormatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         dateFormatterWithMilliseconds.timeZone = TimeZone(abbreviation: "UTC")
+        dateFormatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         
         let dateFormatterWithoutMilliseconds = DateFormatter()
         dateFormatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         dateFormatterWithoutMilliseconds.timeZone = TimeZone(abbreviation: "UTC")
+        dateFormatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         
         if let date = dateFormatterWithMilliseconds.date(from: dateString) {
             return date
@@ -205,4 +207,5 @@ class NightscoutUtils {
         
         return nil
     }
+
 }


### PR DESCRIPTION
## Overview
This PR addresses a bug where the date parsing in `NightscoutUtils` fails when the device is set to a 12-hour time format. The issue stems from the `DateFormatter` not being explicitly set to a locale that supports 24-hour time formats, which can lead to inconsistencies based on the user's device settings.

## Changes
- Set the locale of `dateFormatterWithMilliseconds` and `dateFormatterWithoutMilliseconds` in `NightscoutUtils.parseDate` to `en_US_POSIX`. This locale is designed for machine-readable strings and ensures that the date parsing behavior is consistent, regardless of the user's regional and time format settings.
