### PR TITLE
Add UI update for 'Not Looping' status indication

### DIFF
--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -349,7 +349,7 @@ extension MainViewController {
                 if (UserDefaultsRepository.alertNotLoopingUseLimits.value
                     && (
                         (Float(currentBG) >= UserDefaultsRepository.alertNotLoopingUpperLimit.value
-                            && Float(currentBG) <= UserDefaultsRepository.alertNotLoopingLowerLimit.value) ||
+                            || Float(currentBG) <= UserDefaultsRepository.alertNotLoopingLowerLimit.value) ||
                             // Ignore Limits if BG reading is older than non looping time
                             (Double(now - currentBGTime) >= Double(UserDefaultsRepository.alertNotLooping.value * 60))
                     ) ||

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -46,6 +46,43 @@ extension MainViewController {
             self.startDeviceStatusTimer(time: 10)
         }
     }
+    
+    func evaluateNotLooping(lastLoopTime: TimeInterval) {
+        if let statusStackView = LoopStatusLabel.superview as? UIStackView {
+            if ((TimeInterval(Date().timeIntervalSince1970) - lastLoopTime) / 60) > 15 {
+                IsNotLooping = true
+                // Change the distribution to 'fill' to allow manual resizing of arranged subviews
+                statusStackView.distribution = .fill
+                
+                // Hide PredictionLabel and expand LoopStatusLabel to fill the entire stack view
+                PredictionLabel.isHidden = true
+                LoopStatusLabel.frame = CGRect(x: 0, y: 0, width: statusStackView.frame.width, height: statusStackView.frame.height)
+                
+                // Update LoopStatusLabel's properties to display Not Looping
+                LoopStatusLabel.textAlignment = .center
+                LoopStatusLabel.text = "⚠️ Not Looping!"
+                LoopStatusLabel.textColor = UIColor.systemYellow
+                LoopStatusLabel.font = UIFont.boldSystemFont(ofSize: 18)
+                
+            } else {
+                IsNotLooping = false
+                // Restore the original distribution and visibility of labels
+                statusStackView.distribution = .fillEqually
+                PredictionLabel.isHidden = false
+                
+                // Reset LoopStatusLabel's properties
+                LoopStatusLabel.textAlignment = .right
+                LoopStatusLabel.font = UIFont.systemFont(ofSize: 17)
+
+                if UserDefaultsRepository.forceDarkMode.value {
+                    LoopStatusLabel.textColor = UIColor.white
+                } else {
+                    LoopStatusLabel.textColor = UIColor.black
+                }
+            }
+        }
+        latestLoopTime = lastLoopTime
+    }
         
     // NS Device Status Response Processor
     func updateDeviceStatusDisplay(jsonDeviceStatus: [[String:AnyObject]]) {
@@ -171,12 +208,8 @@ extension MainViewController {
                     }
                     
                 }
-                
-                if ((TimeInterval(Date().timeIntervalSince1970) - lastLoopTime) / 60) > 15 {
-                    LoopStatusLabel.text = "⚠"
-                    latestLoopStatusString = "⚠"
-                }
-                latestLoopTime = lastLoopTime
+
+                evaluateNotLooping(lastLoopTime: lastLoopTime)
             } // end lastLoopTime
         } // end lastLoop Record
         
@@ -305,11 +338,8 @@ extension MainViewController {
                     }
                     
                 }
-                if ((TimeInterval(Date().timeIntervalSince1970) - lastLoopTime) / 60) > 15 {
-                    LoopStatusLabel.text = "⚠"
-                    latestLoopStatusString = "⚠"
-                }
-                latestLoopTime = lastLoopTime
+
+                evaluateNotLooping(lastLoopTime: lastLoopTime)
             }
         }
         

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -1785,7 +1785,7 @@ class AlarmViewController: FormViewController {
                 UserDefaultsRepository.alertNotLoopingUseLimits.value = value
         }
         <<< StepperRow("alertNotLoopingLowerLimit") { row in
-            row.title = "Below BG"
+            row.title = "If Below BG"
             row.cell.stepper.stepValue = 1
             row.cell.stepper.minimumValue = 50
             row.cell.stepper.maximumValue = 200
@@ -1800,7 +1800,7 @@ class AlarmViewController: FormViewController {
                 UserDefaultsRepository.alertNotLoopingLowerLimit.value = Float(value)
         }
         <<< StepperRow("alertNotLoopingUpperLimit") { row in
-            row.title = "Above BG"
+            row.title = "If Above BG"
             row.cell.stepper.stepValue = 1
             row.cell.stepper.minimumValue = 100
             row.cell.stepper.maximumValue = 300

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -149,6 +149,8 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     var lastSpeechTime: Date?
 
     var autoScrollPauseUntil: Date? = nil
+    
+    var IsNotLooping = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -449,7 +451,12 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         }
         
         LoopStatusLabel.isHidden = isHidden
-        PredictionLabel.isHidden = isHidden
+        if IsNotLooping {
+            PredictionLabel.isHidden = true
+        }
+        else {
+            PredictionLabel.isHidden = isHidden
+        }
         infoTable.isHidden = isHidden
         
         if UserDefaultsRepository.hideInfoTable.value {


### PR DESCRIPTION
## Summary
This PR introduces an update to the UI to indicate when Loop/iAPS is 'Not Looping'. The `LoopStatusLabel` is now dynamically updated to expand and fill the entire area designated for loop status messages when no recent loop activity has been confirmed.

## Changes
- Added `evaluateNotLooping` function to determine the 'Not Looping' status.
- UI updates to `LoopStatusLabel` to cover the entire `UIStackView` when not looping.
- `PredictionLabel` is hidden when 'Not Looping' status is active.

## Testing
The changes have been tested to ensure the label updates correctly and the 'Not Looping' status is clear and visible.