### PR TITLE
 Implement Display of Manual BG Values and Standardize Unit Conversion

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		DD7E19882ACDA5DA00DBD158 /* Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E19872ACDA5DA00DBD158 /* Notes.swift */; };
 		DD7E198A2ACDA62600DBD158 /* SensorStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E19892ACDA62600DBD158 /* SensorStart.swift */; };
 		DD7FFAFD2A72953000C3A304 /* EKEventStore+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */; };
+		DD91E4DD2BDEC3F8002D9E97 /* GlucoseConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD91E4DC2BDEC3F8002D9E97 /* GlucoseConversion.swift */; };
 		DD98F54424BCEFEE0007425A /* ShareClientExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */; };
 		DDB0AF522BB1A8BE00AFA48B /* BuildDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */; };
 		DDB0AF552BB1B24A00AFA48B /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = DDB0AF542BB1B24A00AFA48B /* BuildDetails.plist */; };
@@ -212,6 +213,7 @@
 		DD7E19872ACDA5DA00DBD158 /* Notes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notes.swift; sourceTree = "<group>"; };
 		DD7E19892ACDA62600DBD158 /* SensorStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorStart.swift; sourceTree = "<group>"; };
 		DD7FFAFC2A72953000C3A304 /* EKEventStore+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Extensions.swift"; sourceTree = "<group>"; };
+		DD91E4DC2BDEC3F8002D9E97 /* GlucoseConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseConversion.swift; sourceTree = "<group>"; };
 		DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareClientExtension.swift; sourceTree = "<group>"; };
 		DDB0AF502BB1A84500AFA48B /* capture-build-details.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "capture-build-details.sh"; sourceTree = "<group>"; };
 		DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildDetails.swift; sourceTree = "<group>"; };
@@ -689,6 +691,7 @@
 				FC8589BE252B54F500C8FC73 /* Mobileprovision.swift */,
 				DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */,
 				DDB0AF512BB1A8BE00AFA48B /* BuildDetails.swift */,
+				DD91E4DC2BDEC3F8002D9E97 /* GlucoseConversion.swift */,
 			);
 			path = helpers;
 			sourceTree = "<group>";
@@ -1007,6 +1010,7 @@
 				DD493AE92ACF2445009A6922 /* BGData.swift in Sources */,
 				FCC6886B24898FD800A0279D /* ObservationToken.swift in Sources */,
 				DD98F54424BCEFEE0007425A /* ShareClientExtension.swift in Sources */,
+				DD91E4DD2BDEC3F8002D9E97 /* GlucoseConversion.swift in Sources */,
 				FCC6886D2489909D00A0279D /* AnyConvertible.swift in Sources */,
 				FC97881A2485969B00A7906C /* SceneDelegate.swift in Sources */,
 				DD7E198A2ACDA62600DBD158 /* SensorStart.swift in Sources */,

--- a/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
@@ -19,14 +19,17 @@ extension MainViewController {
             guard let dateStr = currentEntry["timestamp"] as? String ?? currentEntry["created_at"] as? String else { return }
             
             guard let parsedDate = NightscoutUtils.parseDate(dateStr),
-                  let sgv = currentEntry["glucose"] as? Int else {
-                if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "ERROR: Non-Int Glucose entry") }
+                  let glucose = currentEntry["glucose"] as? Double else {
+                if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "ERROR: Non-Double Glucose entry") }
                 return
             }
             
+            let units = currentEntry["units"] as? String ?? "mg/dl"
+            let convertedGlucose: Double = units == "mmol" ? glucose * GlucoseConversion.mmolToMgDl : glucose
+
             let dateTimeStamp = parsedDate.timeIntervalSince1970
             if dateTimeStamp < (dateTimeUtils.getNowTimeIntervalUTC() + (60 * 60)) {
-                let dot = ShareGlucoseData(sgv: sgv, date: Double(dateTimeStamp), direction: "")
+                let dot = ShareGlucoseData(sgv: Int(convertedGlucose.rounded()), date: Double(dateTimeStamp), direction: "")
                 bgCheckData.append(dot)
             }
         }
@@ -36,3 +39,4 @@ extension MainViewController {
         }
     }
 }
+

--- a/LoopFollow/Controllers/Stats.swift
+++ b/LoopFollow/Controllers/Stats.swift
@@ -70,7 +70,7 @@ class StatsData {
         
         stdDev = sqrt(partialSum / Float(bgData.count))
         if UserDefaultsRepository.units.value != "mg/dL" {
-            stdDev = stdDev / 18
+            stdDev = stdDev * Float(GlucoseConversion.mgDlToMmolL)
         }
         
         if UserDefaultsRepository.useIFCC.value {

--- a/LoopFollow/Extensions/ShareClientExtension.swift
+++ b/LoopFollow/Extensions/ShareClientExtension.swift
@@ -9,29 +9,31 @@
 import Foundation
 import ShareClient
 
-public struct ShareGlucoseData: Codable {
+public struct ShareGlucoseData: Decodable {
     var sgv: Int
     var date: TimeInterval
     var direction: String?
 
     enum CodingKeys: String, CodingKey {
-        case sgv
+        case sgv  // Sensor Blood Glucose
+        case mbg  // Manual Blood Glucose
         case date
         case direction
     }
 
+    // Decoder initializer for handling JSON data
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        if let sgvAsDouble = try? container.decode(Double.self, forKey: .sgv) {
-            sgv = Int(sgvAsDouble.rounded())
-        } else if let sgvAsInt = try? container.decode(Int.self, forKey: .sgv) {
-            sgv = sgvAsInt
+        
+        if let glucoseValue = try? container.decode(Double.self, forKey: .sgv) {
+            sgv = Int(glucoseValue.rounded())
+        } else if let mbgValue = try? container.decode(Double.self, forKey: .mbg) {
+            sgv = Int(mbgValue.rounded())
         } else {
-            throw DecodingError.dataCorruptedError(forKey: .sgv, in: container, debugDescription: "Expected to decode an Integer or Double.")
+            throw DecodingError.dataCorruptedError(forKey: .sgv, in: container, debugDescription: "Expected to decode Double for sgv or mbg.")
         }
-
-        // Decode the other properties
+    
+        // Decode the date and optional direction
         date = try container.decode(TimeInterval.self, forKey: .date)
         direction = try container.decodeIfPresent(String.self, forKey: .direction)
     }

--- a/LoopFollow/helpers/GlucoseConversion.swift
+++ b/LoopFollow/helpers/GlucoseConversion.swift
@@ -1,0 +1,14 @@
+//
+//  GlucoseConversion.swift
+//  LoopFollow
+//
+//  Created by Jonas Björkert on 2024-04-28.
+//  Copyright © 2024 Jon Fawcett. All rights reserved.
+//
+
+import Foundation
+
+struct GlucoseConversion {
+    static let mgDlToMmolL: Double = 0.0555
+    static let mmolToMgDl: Double = 18.01559
+}

--- a/LoopFollow/helpers/NightscoutUtils.swift
+++ b/LoopFollow/helpers/NightscoutUtils.swift
@@ -33,7 +33,7 @@ class NightscoutUtils {
             case .cage, .carbsToday, .sage, .treatments:
                 return "/api/v1/treatments.json"
             case .sgv:
-                return "/api/v1/entries/sgv.json"
+                return "/api/v1/entries.json"
             case .profile:
                 return "/api/v1/profile/current.json"
             case .deviceStatus: 

--- a/LoopFollow/helpers/bgUnits.swift
+++ b/LoopFollow/helpers/bgUnits.swift
@@ -29,7 +29,7 @@ class bgUnits {
                 let numberValue = NSNumber(value: number)
                 return numberFormatter.string(from: numberValue) ?? value
             } else {
-                let mmolValue = number / 18
+                let mmolValue = Double(number) * GlucoseConversion.mgDlToMmolL  // Convert number to Double
                 let numberValue = NSNumber(value: mmolValue)
                 return numberFormatter.string(from: numberValue) ?? value
             }


### PR DESCRIPTION
This PR introduces the display of manual BG values from Loop and Apple Health in the app's graphs. It also ensures that manual BG check entries from Nightscout using mmol are correctly shown. Additionally, the PR standardizes mmol/L <-> mg/dL conversions throughout the application using centralized constants for improved consistency and maintainability.