### PR TITLE
Notification of new version, blacklisted version and build expiration

### DIFF
--- a/LoopFollow/Application/AppDelegate.swift
+++ b/LoopFollow/Application/AppDelegate.swift
@@ -42,7 +42,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          return true
       }
         
-   
     func applicationWillTerminate(_ application: UIApplication) {
         if UserDefaultsRepository.alertAppInactive.value {
             AlarmSound.setSoundFile(str: "Alarm_Buzzer")

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -436,7 +436,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             if isBlacklisted {
                 let lastBlacklistShown = UserDefaultsRepository.lastBlacklistNotificationShown.value ?? Date.distantPast
                 if now.timeIntervalSince(lastBlacklistShown) > 86400 { // 24 hours
-                    self.versionAlert(message: "The current version has a critical issue and should be updated immediately.")
+                    self.versionAlert(message: "The current version has a critical issue and should be updated as soon as possible.")
                     UserDefaultsRepository.lastBlacklistNotificationShown.value = now
                     UserDefaultsRepository.lastVersionUpdateNotificationShown.value = now
                 }

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -423,9 +423,63 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         }
         
         restartAllTimers()
-
+        checkAndNotifyVersionStatus()
+        checkAppExpirationStatus()
     }
     
+    func checkAndNotifyVersionStatus() {
+        let versionManager = AppVersionManager()
+        versionManager.checkForNewVersion { latestVersion, isNewer, isBlacklisted in
+            let now = Date()
+            
+            // Check if the current version is blacklisted, or if there is a newer version available
+            if isBlacklisted {
+                let lastBlacklistShown = UserDefaultsRepository.lastBlacklistNotificationShown.value ?? Date.distantPast
+                if now.timeIntervalSince(lastBlacklistShown) > 86400 { // 24 hours
+                    self.versionAlert(message: "The current version has a critical issue and should be updated immediately.")
+                    UserDefaultsRepository.lastBlacklistNotificationShown.value = now
+                    UserDefaultsRepository.lastVersionUpdateNotificationShown.value = now
+                }
+            } else if isNewer {
+                let lastVersionUpdateShown = UserDefaultsRepository.lastVersionUpdateNotificationShown.value ?? Date.distantPast
+                if now.timeIntervalSince(lastVersionUpdateShown) > 1209600 { // 2 weeks
+                    self.versionAlert(message: "A new version is available: \(latestVersion ?? "Unknown"). It is recommended to update.")
+                    UserDefaultsRepository.lastVersionUpdateNotificationShown.value = now
+                }
+            }
+        }
+    }
+
+    func versionAlert(title: String = "Update Available", message: String) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true)
+        }
+    }
+
+    func checkAppExpirationStatus() {
+        let now = Date()
+        let expirationDate = BuildDetails.default.calculateExpirationDate()
+        let weekBeforeExpiration = Calendar.current.date(byAdding: .day, value: -7, to: expirationDate)!
+        
+        if now >= weekBeforeExpiration {
+            let lastExpirationShown = UserDefaultsRepository.lastExpirationNotificationShown.value ?? Date.distantPast
+            if now.timeIntervalSince(lastExpirationShown) > 86400 { // 24 hours
+                expirationAlert()
+                UserDefaultsRepository.lastExpirationNotificationShown.value = now
+            }
+        }
+    }
+
+    func expirationAlert() {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "App Expiration Warning", message: "This app will expire in less than a week. Please rebuild to continue using it.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true)
+        }
+    }
+
     @objc override func viewDidAppear(_ animated: Bool) {
         showHideNSDetails()
     }

--- a/LoopFollow/helpers/AppVersionManager.swift
+++ b/LoopFollow/helpers/AppVersionManager.swift
@@ -48,10 +48,10 @@ class AppVersionManager {
                         .map { $0.blacklistedVersions.map { $0.version }.contains(currentVersion) } ?? false
                     
                     // Update cache with new data
-                    UserDefaults.standard.set(fetchedVersion, forKey: "latestVersion")
-                    UserDefaults.standard.set(Date(), forKey: "latestVersionChecked")
-                    UserDefaults.standard.set(isBlacklisted, forKey: "isCurrentVersionBlacklisted")
-                    UserDefaults.standard.set(currentVersion, forKey: "cachedForVersion")
+                    UserDefaultsRepository.latestVersion.value = fetchedVersion
+                    UserDefaultsRepository.latestVersionChecked.value = Date()
+                    UserDefaultsRepository.currentVersionBlackListed.value = isBlacklisted
+                    UserDefaultsRepository.cachedForVersion.value = currentVersion
                     
                     // Call completion with new data
                     completion(fetchedVersion, isNewer, isBlacklisted)

--- a/LoopFollow/helpers/AppVersionManager.swift
+++ b/LoopFollow/helpers/AppVersionManager.swift
@@ -24,6 +24,12 @@ class AppVersionManager {
         let currentVersionBlackListed = UserDefaultsRepository.currentVersionBlackListed.value
         let cachedForVersion = UserDefaultsRepository.cachedForVersion.value
         
+        // Reset notifications if version has changed
+        if let cachedVersion = cachedForVersion, cachedVersion != currentVersion {
+            UserDefaultsRepository.lastBlacklistNotificationShown.value = Date.distantPast
+            UserDefaultsRepository.lastVersionUpdateNotificationShown.value = Date.distantPast
+        }
+        
         // Check if the cache is still valid
         if let cachedVersion = cachedForVersion, cachedVersion == currentVersion,
            now.timeIntervalSince(latestVersionChecked) < 24 * 3600, let latestVersion = latestVersion {

--- a/LoopFollow/helpers/BuildDetails.swift
+++ b/LoopFollow/helpers/BuildDetails.swift
@@ -71,7 +71,7 @@ class BuildDetails {
             if let provision = MobileProvision.read() {
                 return provision.expirationDate
             } else {
-                return Date()
+                return .distantFuture
             }
         }
     }

--- a/LoopFollow/helpers/GitHubService.swift
+++ b/LoopFollow/helpers/GitHubService.swift
@@ -18,6 +18,7 @@ class GitHubService {
             case .versionConfig:
                 return "https://raw.githubusercontent.com/loopandlearn/LoopFollow/main/Config.xcconfig"
             case .blacklistedVersions:
+                return "https://raw.githubusercontent.com/bjorkert/LoopFollow/Main/blacklisted-versions.json"
                 return "https://raw.githubusercontent.com/loopandlearn/LoopFollow/main/blacklisted-versions.json"
             }
         }

--- a/LoopFollow/helpers/GitHubService.swift
+++ b/LoopFollow/helpers/GitHubService.swift
@@ -18,7 +18,6 @@ class GitHubService {
             case .versionConfig:
                 return "https://raw.githubusercontent.com/loopandlearn/LoopFollow/main/Config.xcconfig"
             case .blacklistedVersions:
-                return "https://raw.githubusercontent.com/bjorkert/LoopFollow/Main/blacklisted-versions.json"
                 return "https://raw.githubusercontent.com/loopandlearn/LoopFollow/main/blacklisted-versions.json"
             }
         }

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -460,10 +460,20 @@ class UserDefaultsRepository {
     static let alertRecBolusSnoozedTime = UserDefaultsValue<Date?>(key: "alertRecBolusSnoozedTime", default: nil)
     static var deviceRecBolus: UserDefaultsValue<Double> = UserDefaultsValue(key: "deviceRecBolus", default: 0.0)
 
+    //What version is the cache valid for
+    static let cachedForVersion = UserDefaultsValue<String?>(key: "cachedForVersion", default: nil)
+
     //Caching of latest version
     static let latestVersion = UserDefaultsValue<String?>(key: "latestVersion", default: nil)
     static let latestVersionChecked = UserDefaultsValue<Date?>(key: "latestVersionChecked", default: nil)
 
     //Caching of blacklisted version
     static let currentVersionBlackListed = UserDefaultsValue<Bool>(key: "currentVersionBlackListed", default: false)
+
+    // Tracking notifications to manage frequency
+    static let lastBlacklistNotificationShown = UserDefaultsValue<Date?>(key: "lastBlacklistNotificationShown", default: nil)
+    static let lastVersionUpdateNotificationShown = UserDefaultsValue<Date?>(key: "lastVersionUpdateNotificationShown", default: nil)
+    
+    // Tracking the last time the expiration notification was shown
+    static let lastExpirationNotificationShown = UserDefaultsValue<Date?>(key: "lastExpirationNotificationShown", default: nil)
 }


### PR DESCRIPTION
This pull request introduces improved notifications for version updates, blacklisting, and build expiration, aiming to enhance user experience by keeping them informed about essential updates and app validity.

Version and Blacklist Notifications:
The application now checks for new versions and blacklisting status each time it becomes active. Notifications for new versions are shown biweekly, while blacklist notifications are shown daily if applicable.
Utilizes caching to reduce network calls. Cache validity is tied to the app version, ensuring data relevance.

Build Expiration Notification:
Alerts users if the app will expire within a week, with daily notifications to prompt action.
Useful for TestFlight builds or other distributions with set expiration dates.
Caching Enhancements:

Introduces cachedForVersion to manage cache validity per app version, refreshing cache data upon new version launches.