### PR TITLE
Remove Download Loop/iAPS Data toggle

### DIFF
--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -175,7 +175,7 @@ extension MainViewController {
     @objc func deviceStatusTimerDidEnd(_ timer:Timer) {
         
         // reset timer to 1 minute if settings aren't entered
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             startDeviceStatusTimer(time: 60)
             return
         }
@@ -200,7 +200,7 @@ extension MainViewController {
         
         
         // reset timer to 1 minute if settings aren't entered
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             startTreatmentsTimer(time: 60)
             return
         }
@@ -225,7 +225,7 @@ extension MainViewController {
     @objc func profileTimerDidEnd(_ timer:Timer) {
         
         // reset timer to 1 minute if settings aren't entered
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             startProfileTimer(time: 60)
             return
         }

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -437,7 +437,7 @@ class AlarmViewController: FormViewController {
     func showHideNSDetails() {
         var isHidden = false
         var isEnabled = true
-        if UserDefaultsRepository.url.value == ""  || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             isHidden = true
             isEnabled = false
         }

--- a/LoopFollow/ViewControllers/GraphSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GraphSettingsViewController.swift
@@ -29,7 +29,7 @@ class GraphSettingsViewController: FormViewController {
     func showHideNSDetails() {
         var isHidden = false
         var isEnabled = true
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             isHidden = true
             isEnabled = false
         }

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -445,7 +445,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     func showHideNSDetails() {
         var isHidden = false
         var isEnabled = true
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             isHidden = true
             isEnabled = false
         }

--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -19,8 +19,7 @@ class SettingsViewController: FormViewController {
     func showHideNSDetails() {
         var isHidden = false
         var isEnabled = true
-        var isLoopHidden = false;
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             isHidden = true
             isEnabled = false
         }
@@ -202,16 +201,6 @@ class SettingsViewController: FormViewController {
            statusLabelRow = row
            row.hidden = "$showNS == false"
        }
-       <<< SwitchRow("loopUser"){ row in
-           row.title = "Download Loop/iAPS Data"
-           row.tag = "loopUser"
-           row.value = UserDefaultsRepository.loopUser.value
-           row.hidden = "$showNS == false"
-       }.onChange { row in
-                   guard let value = row.value else { return }
-                   UserDefaultsRepository.loopUser.value = value
-           }
-        
        <<< SwitchRow("showDex"){ row in
        row.title = "Show Dexcom Settings"
        row.value = UserDefaultsRepository.showDex.value

--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -155,21 +155,21 @@ class SettingsViewController: FormViewController {
            if !useTokenUrl {
                // Normalize input: remove unwanted characters and lowercase
                let filtered = value.replacingOccurrences(of: "[^A-Za-z0-9:/._-]", with: "", options: .regularExpression).lowercased()
-               
+
                // Further clean-up: Remove trailing slashes
                var cleanURL = filtered
-               while cleanURL.last == "/" {
+               while cleanURL.count > 8 && cleanURL.last == "/" {
                    cleanURL = String(cleanURL.dropLast())
                }
-               
+
                UserDefaultsRepository.url.value = cleanURL
                row.value = cleanURL
                row.updateCell()
            }
-           
+
            self.showHideNSDetails()
            globalVariables.nsVerifiedAlert = 0
-           
+
            // Verify Nightscout URL and token
            self.checkNightscoutStatus()
        }

--- a/LoopFollow/ViewControllers/WatchSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/WatchSettingsViewController.swift
@@ -36,7 +36,7 @@ class WatchSettingsViewController: FormViewController {
     func showHideNSDetails() {
         var isHidden = false
         var isEnabled = true
-        if UserDefaultsRepository.url.value == "" || !UserDefaultsRepository.loopUser.value {
+        if UserDefaultsRepository.url.value == "" {
             isHidden = true
             isEnabled = false
         }

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -42,7 +42,6 @@ class UserDefaultsRepository {
     static let url = UserDefaultsValue<String>(key: "url", default: "")
     static let token = UserDefaultsValue<String>(key: "token", default: "")
     static let units = UserDefaultsValue<String>(key: "units", default: "mg/dL")
-    static let loopUser = UserDefaultsValue<Bool>(key: "loopUser", default: false)
     
     // Dexcom Share Settings
     static let showDex = UserDefaultsValue<Bool>(key: "showDex", default: false)


### PR DESCRIPTION
In an effort to simplify the functionality and improve user experience, we have made a small update to the LoopFollow app. Previously, users had to manually toggle the option to download Nightscout data, dependent on a separate 'Download Loop/iAPS Data' setting. This has been streamlined to enhance efficiency and ease of use.

**Key Change:**
Automatic Data Download: The toggle for 'Download Loop/iAPS Data' has been removed. Now, the app will automatically start downloading Nightscout data whenever a URL is entered. This change ensures that users won't need to manage additional settings to start receiving data, reducing setup complexity and potential user errors.
This update is part of our ongoing efforts to make LoopFollow more intuitive and user-friendly, ensuring that your focus can remain on what's most important—managing health data effectively.

As always, we are eager to hear your feedback as we continue to improve the app. Please share your thoughts and experiences after this update.

Ping @MikePlante1 