### PR TITLE
Update Fastlane to 2.221.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,22 +5,22 @@ GEM
       base64
       nkf
       rexml
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.921.0)
-    aws-sdk-core (3.193.0)
+    aws-partitions (1.949.0)
+    aws-sdk-core (3.200.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.80.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-kms (1.87.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.148.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-s3 (1.155.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
@@ -69,7 +69,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.3.1)
-    fastlane (2.220.0)
+    fastlane (2.221.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -148,31 +148,32 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
-    http-cookie (1.0.5)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
     httpclient (2.8.3)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
-    mini_magick (4.12.0)
+    mini_magick (4.13.1)
     mini_mime (1.1.5)
     multi_json (1.15.0)
-    multipart-post (2.4.0)
+    multipart-post (2.4.1)
     nanaimo (0.3.0)
     naturally (2.2.1)
     nkf (0.2.0)
     optparse (0.5.0)
     os (1.1.4)
     plist (3.7.1)
-    public_suffix (5.0.5)
+    public_suffix (5.1.1)
     rake (13.2.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.2.9)
+      strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -185,6 +186,7 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    strscan (3.1.0)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -216,6 +218,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
Some Fastlane error were reported in iAPS.
These could be solved by updating Fastlane to 2.221.1

In order to prevent errors happening with LoopFollow, go on and update it to Fastlane 2.221.1.