### PR TITLE
Correct DeviceStatus Download Count and Dynamic BGData Download Limit

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -63,7 +63,7 @@ extension MainViewController {
         var parameters: [String: String] = [:]
         let utcISODateFormatter = ISO8601DateFormatter()
         let date = Calendar.current.date(byAdding: .day, value: -1 * UserDefaultsRepository.downloadDays.value, to: Date())!
-        parameters["count"] = "1000"
+        parameters["count"] = "\(UserDefaultsRepository.downloadDays.value * 2 * 24 * 60 / 5)"
         parameters["find[dateString][$gte]"] = utcISODateFormatter.string(from: date)
         
         NightscoutUtils.executeRequest(eventType: .sgv, parameters: parameters) { (result: Result<[ShareGlucoseData], Error>) in

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -17,7 +17,7 @@ extension MainViewController {
             self.writeDebugLog(value: "Download: device status")
         }
         
-        let parameters: [String: String] = ["count": "288"]
+        let parameters: [String: String] = ["count": "1"]
         NightscoutUtils.executeDynamicRequest(eventType: .deviceStatus, parameters: parameters) { result in
             switch result {
             case .success(let json):


### PR DESCRIPTION
**1.	DeviceStatus.swift:**
	•	Corrected the count parameter for device status downloads from 288 to 1, as only one record is needed. The initial value was a copy-paste error, which led to unnecessary data being downloaded.
**2.	BGData.swift:**
	•	Adjusted the count parameter to dynamically calculate the limit of BG values to download. The new formula accounts for both Loop/Trio and Dexcom Share data, leading to 2 * 288 BG values per day.
	•	Previous hardcoded value: 1000. Two days of double data results in 1152 values.
	•	New dynamic value: UserDefaultsRepository.downloadDays.value * 2 * 24 * 60 / 5