### PR TITLE
Add IDEPreferLogStreaming env. variable to Launch and Profile actions

### DIFF
--- a/LoopFollow.xcworkspace/xcshareddata/xcschemes/LoopFollow.xcscheme
+++ b/LoopFollow.xcworkspace/xcshareddata/xcschemes/LoopFollow.xcscheme
@@ -49,6 +49,13 @@
             ReferencedContainer = "container:LoopFollow.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -66,6 +73,13 @@
             ReferencedContainer = "container:LoopFollow.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Inspired by this PR to Loop
https://github.com/LoopKit/LoopWorkspace/pull/183

This PR resolves the logging initialization error when building to an iOS 17.5.1 device by adding the `IDEPreferLogStreaming` environment variable to the Launch and Profile actions in the LoopFollow scheme.

### Summary of Changes
- **Added**: `IDEPreferLogStreaming=YES` to `.xcscheme` file.
- **Fixes**: Error message "Logging Error: Failed to initialize logging system. Log messages may be missing."

### Result
The initial error message is no longer seen in the Xcode debug log.