### PR TITLE
Set LSMinimumSystemVersion resolve macOS compatibility issue

### DIFF
--- a/LoopFollow/Info.plist
+++ b/LoopFollow/Info.plist
@@ -98,5 +98,7 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Summary
This PR updates the `Info.plist` to set `LSMinimumSystemVersion` to `13.0` to address the ITMS-90899 issue raised by Apple regarding macOS compatibility for Apple Silicon Macs.

### Context
Apple notifies that the app isn’t compatible with macOS 12.5 and needs to target macOS 13.0 or later. This change ensures compliance and resolves the warning during builds.

### Impact
This update should prevent further warnings related to macOS version compatibility in future builds.

![CleanShot 2024-08-11 at 19 55 42](https://github.com/user-attachments/assets/d10363a8-2814-499b-b7de-0127464f6def)
