### PR TITLE
Filter out cal entries

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -65,6 +65,9 @@ extension MainViewController {
         let date = Calendar.current.date(byAdding: .day, value: -1 * UserDefaultsRepository.downloadDays.value, to: Date())!
         parameters["count"] = "\(UserDefaultsRepository.downloadDays.value * 2 * 24 * 60 / 5)"
         parameters["find[dateString][$gte]"] = utcISODateFormatter.string(from: date)
+
+        // Exclude 'cal' entries
+        parameters["find[type][$ne]"] = "cal"
         
         NightscoutUtils.executeRequest(eventType: .sgv, parameters: parameters) { (result: Result<[ShareGlucoseData], Error>) in
             switch result {


### PR DESCRIPTION
A small fix to filter out cal type entries from the bg result from Nightscout.

These entries would stop the bg value to be visible until they are out of scope for the fetch of data from Nightscout.

Preferably we should in the code filter out any type we don't want to use but this is what I have bandwidth to do right now.