### PR TITLE
Unit and timezone handling

### DIFF
--- a/LoopFollow/Controllers/Nightscout/NSProfile.swift
+++ b/LoopFollow/Controllers/Nightscout/NSProfile.swift
@@ -42,6 +42,8 @@ struct NSProfile: Decodable {
         let target_high: [TargetEntry]?
         let target_low: [TargetEntry]?
         let timezone: String
+
+        let units: String
     }
 
     let store: [String: Store]


### PR DESCRIPTION
**Summary of Changes:**

This Pull Request introduces two main changes:

1. **Use Units from the Profile Store Instead of the Top-Level Units**

   - **Description:**
     - The units used within the profile's store (`store.units`) can differ from the units specified at the main level (`profileData.units`) when using Loop.
     - Since the units are primarily used for interpreting profile data (e.g., basal rates, carb ratios), it makes sense to prioritize the units specified within the profile store.
     - This change modifies the code to use the units from the profile's default store (`store.units`) when loading profile data.

   - **Implementation Details:**
     - Updated the `loadProfile` function to source `self.units` from `store.units` instead of `profileData.units`.
     - Added the `units` property to the `NSProfile.Store` struct to facilitate this change.

   - **Future Considerations:**
     - In the future, we may need to handle scenarios where both units are relevant.

2. **Time Zone Support for Profile Data Based on Looper's Time Zone**

   - **Description:**
     - When the looper is in a different time zone than the LoopFollow user, it's important to use the looper's time zone for accurate schedule-based setting displays (e.g., carb ratio, target range, basal rates).
     - This change updates the code to use the time zone specified in the profile (`store.timezone`) when determining the current profile data.

   - **Implementation Details:**
     - Modified the `getCurrentValue` function to use the profile's time zone instead of the device's local time.
     - Implemented a helper function `getTimeZone(from:)` to handle various time zone formats and parse them into `TimeZone` objects.
     - Cached the parsed `TimeZone` object in the `ProfileManager` to avoid re-evaluating it on each call, improving performance.

   - **Time Zone Format Handling:**
     - The code now supports different time zone formats, such as `"Europe/Stockholm"` and `"Etc/GMT-2"`.
     - Adjusted casing and parsing logic to handle variations like `"ETC/GMT-2"` by normalizing them to standard IANA time zone identifiers.

Thanks to Odd Stoltenberg for reporting these two issues.