### PR TITLE
TRC debug info

### DIFF
--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -192,6 +192,13 @@ struct RemoteSettingsView: View {
                         Toggle("Meal with Fat/Protein", isOn: $viewModel.mealWithFatProtein)
                             .toggleStyle(SwitchToggleStyle())
                     }
+
+                    Section(header: Text("Debug / Info")) {
+                        Text("Device Token: \(Storage.shared.deviceToken.value)")
+                        Text("Production Env.: \(Storage.shared.productionEnvironment.value ? "True" : "False")")
+                        Text("Team ID: \(Storage.shared.teamId.value ?? "")")
+                        Text("Bundle ID: \(Storage.shared.bundleId.value)")
+                    }
                 }
             }
             .navigationBarTitle("Remote Settings", displayMode: .inline)


### PR DESCRIPTION
Added information about device token, production env, team id and bundle id in the bottom of the Remote/TRC screen.

I verified that switching build method for Trio changes the production env boolean without restarting LoopFollow. Please note, the production env bool is in the profile and the profile information is refreshed every 10 minutes.

![CleanShot 2024-12-06 at 21 12 42@2x](https://github.com/user-attachments/assets/2965b419-be06-4bd4-8203-c5dd379cdbfb)
