### PR TITLE
Align Carb and Bolus Guardrail Behavior

### DIFF
--- a/LoopFollow/Helpers/TextFieldWithToolBar.swift
+++ b/LoopFollow/Helpers/TextFieldWithToolBar.swift
@@ -185,6 +185,7 @@ public struct TextFieldWithToolBar: UIViewRepresentable {
                             message += "Maximum: \(self.format(quantity: maxValue, for: self.unit))"
                         }
                         self.onValidationError(message)
+                        self.parent.quantity = HKQuantity(unit: self.unit, doubleValue: 0)
                     }
                 } else {
                     self.onValidationError("Invalid number format")

--- a/LoopFollow/Remote/TRC/MealView.swift
+++ b/LoopFollow/Remote/TRC/MealView.swift
@@ -137,9 +137,10 @@ struct MealView: View {
                                         fat.doubleValue(for: .gram()) != 0 else {
                                     return
                                 }
-
-                                alertType = .confirmMeal
-                                showAlert = true
+                                if !showAlert {
+                                    alertType = .confirmMeal
+                                    showAlert = true
+                                }
                             }
                         },
                         isDisabled: isButtonDisabled


### PR DESCRIPTION
Before, the last valid value was used for the meal entry. Now the invalid value is cleared and the error message is displayed correctly.