### PR TITLE
Require auth for meal bolus

### DIFF
--- a/LoopFollow/Remote/TRC/MealView.swift
+++ b/LoopFollow/Remote/TRC/MealView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import HealthKit
+import LocalAuthentication
 
 struct MealView: View {
     @Environment(\.presentationMode) private var presentationMode
@@ -192,7 +193,15 @@ struct MealView: View {
                         message: Text(message),
                         primaryButton: .default(Text("Confirm"), action: {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                sendMealCommand()
+                                if bolusAmount > 0 {
+                                    authenticateUser { success in
+                                        if success {
+                                            sendMealCommand()
+                                        }
+                                    }
+                                } else {
+                                    sendMealCommand()
+                                }
                             }
                         }),
                         secondaryButton: .cancel()
@@ -279,5 +288,30 @@ struct MealView: View {
         alertMessage = message
         alertType = .validationError
         showAlert = true
+    }
+
+    private func authenticateUser(completion: @escaping (Bool) -> Void) {
+        let context = LAContext()
+        var error: NSError?
+
+        let reason = "Confirm your identity to send bolus."
+
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+            context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
+                DispatchQueue.main.async {
+                    completion(success)
+                }
+            }
+        } else if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
+                DispatchQueue.main.async {
+                    completion(success)
+                }
+            }
+        } else {
+            DispatchQueue.main.async {
+                completion(false)
+            }
+        }
     }
 }


### PR DESCRIPTION
With this change, a authentication is required for bolusing with meals. When there is no bolus, no auth is required.