### PR TITLE
Limit displayed override duration to 'Hours of Prediction' after current time

### DIFF
--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -56,12 +56,14 @@ extension MainViewController {
                 if (low == nil && high != nil) || (low != nil && high == nil) { return }
                 range = [low ?? 0, high ?? 0]
             }
-            
+
+            // Limit displayed override duration to 'Hours of Prediction' after current time
             var endDate = dateTimeStamp + duration
-/*            if endDate > maxEndDate {
+            if endDate > maxEndDate {
                 endDate = maxEndDate
+                duration = endDate - dateTimeStamp
             }
-*/
+
             if dateTimeStamp <= now && now < endDate {
                 activeOverrideNote = currentEntry["notes"] as? String
             }

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -48,7 +48,7 @@ class TaskScheduler {
     }
 
     func rescheduleTask(id: TaskID, to newRunDate: Date) {
-        let timeString = self.formatTime(newRunDate)
+        //let timeString = self.formatTime(newRunDate)
         //LogManager.shared.log(category: .taskScheduler, message: "Reschedule Task \(id): next run = \(timeString)", isDebug: true)
 
         queue.async {

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -49,7 +49,7 @@ class TaskScheduler {
 
     func rescheduleTask(id: TaskID, to newRunDate: Date) {
         let timeString = self.formatTime(newRunDate)
-        LogManager.shared.log(category: .taskScheduler, message: "Reschedule Task \(id): next run = \(timeString)", isDebug: true)
+        //LogManager.shared.log(category: .taskScheduler, message: "Reschedule Task \(id): next run = \(timeString)", isDebug: true)
 
         queue.async {
             guard var existingTask = self.tasks[id] else {
@@ -124,7 +124,7 @@ class TaskScheduler {
             updatedTask.nextRun = .distantFuture
             tasks[taskID] = updatedTask
 
-            LogManager.shared.log(category: .taskScheduler, message: "Executing task \(taskID)", isDebug: true)
+            //LogManager.shared.log(category: .taskScheduler, message: "Executing task \(taskID)", isDebug: true)
 
             DispatchQueue.main.async {
                 task.action()

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -48,8 +48,8 @@ class TaskScheduler {
     }
 
     func rescheduleTask(id: TaskID, to newRunDate: Date) {
-        //let timeString = self.formatTime(newRunDate)
-        //LogManager.shared.log(category: .taskScheduler, message: "Reschedule Task \(id): next run = \(timeString)", isDebug: true)
+        let timeString = self.formatTime(newRunDate)
+        LogManager.shared.log(category: .taskScheduler, message: "Reschedule Task \(id): next run = \(timeString)", isDebug: true)
 
         queue.async {
             guard var existingTask = self.tasks[id] else {
@@ -124,7 +124,7 @@ class TaskScheduler {
             updatedTask.nextRun = .distantFuture
             tasks[taskID] = updatedTask
 
-            //LogManager.shared.log(category: .taskScheduler, message: "Executing task \(taskID)", isDebug: true)
+            LogManager.shared.log(category: .taskScheduler, message: "Executing task \(taskID)", isDebug: true)
 
             DispatchQueue.main.async {
                 task.action()


### PR DESCRIPTION
Solves https://github.com/loopandlearn/LoopFollow/issues/354

This PR limits displayed override duration to 'Hours of Prediction' after current time.