### PR TITLE
Improved Duplicate Handling in Nightscout BG Data Processing

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -74,25 +74,18 @@ extension MainViewController {
                         nsData[i].date /= 1000
                         nsData[i].date.round(FloatingPointRoundingRule.toNearestOrEven)
                     }
-                    print(nsData.count)
-                    
-                    //Avoid duplicate entries messing up the graph, only use one reading per 5 minutes.
-                    let graphHours = 24 * UserDefaultsRepository.downloadDays.value
-                    let points = graphHours * 12 + 1
-                    var nsData2 = [ShareGlucoseData]()
-                    let timestamp = Date().timeIntervalSince1970
-                    for i in 0..<points {
-                        //Starting with "now" and then step 5 minutes back in time
-                        let target = timestamp - Double(i) * 60 * 5
-                        //Find the reading closest to the target, but not too far away
-                        let closest = nsData.filter{ abs($0.date - target) < 3 * 60 }.min { abs($0.date - target) < abs($1.date - target) }
-                        //If a reading is found, add it to the new array
-                        if let item = closest {
-                            nsData2.append(item)
+
+                    var nsData2: [ShareGlucoseData] = []
+                    var lastAddedTime = Double.infinity
+                    let minInterval: Double = 4 * 60
+
+                    for reading in nsData {
+                        if lastAddedTime - reading.date >= minInterval {
+                            nsData2.append(reading)
+                            lastAddedTime = reading.date
                         }
                     }
-                    print(nsData2.count)
-                    
+
                     // merge NS and Dex data if needed; use recent Dex data and older NS data
                     var sourceName = "Nightscout"
                     if !dexData.isEmpty {


### PR DESCRIPTION
Resolves https://github.com/loopandlearn/LoopFollow/issues/357

This update fixes an issue where duplicate glucose readings (nightscout dexcom bridge and Loop or Trio) were were sometimes included, resulting in a delta of 0. The new logic ensures that readings are spaced at least 4 minutes apart, preventing duplicate values from affecting calculations.

Additionally, the previous method, which iterated through multiple time buckets and filtered the closest reading, has been replaced with a more efficient single-pass approach. This results in faster processing while maintaining accurate data selection.

Fixes:
	•	Eliminates near-duplicate readings that caused incorrect delta calculations.
	•	Improves performance by removing unnecessary filtering operations.