### PR TITLE
Dynamic calculation of bg delay

### DIFF
--- a/LoopFollow/BackgroundRefresh/BT/BLEDeviceSelectionView.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BLEDeviceSelectionView.swift
@@ -13,13 +13,14 @@ struct BLEDeviceSelectionView: View {
     var body: some View {
         VStack {
             List {
-                if bleManager.devices.filter({ selectedFilter.matches($0) && !isSelected($0) }).isEmpty {
+                let filteredDevices = bleManager.devices.filter { selectedFilter.matches($0) && !isSelected($0) }
+                if filteredDevices.isEmpty {
                     Text("No devices found yet. They'll appear here when discovered.")
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                         .padding()
                 } else {
-                    ForEach(bleManager.devices.filter { selectedFilter.matches($0) && !isSelected($0) }, id: \.id) { device in
+                    ForEach(filteredDevices, id: \.id) { device in
                         HStack {
                             VStack(alignment: .leading) {
                                 Text(device.name ?? "Unknown")
@@ -27,6 +28,12 @@ struct BLEDeviceSelectionView: View {
                                 Text("RSSI: \(device.rssi) dBm")
                                     .foregroundColor(.secondary)
                                     .font(.footnote)
+
+                                if let offset = BLEManager.shared.expectedSensorFetchOffsetString(for: device) {
+                                    Text("Expected fetch offset: \(offset)")
+                                        .foregroundColor(.secondary)
+                                        .font(.footnote)
+                                }
                             }
                             Spacer()
                         }

--- a/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsView.swift
+++ b/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsView.swift
@@ -97,6 +97,11 @@ struct BackgroundRefreshSettingsView: View {
                             .foregroundColor(.secondary)
                             .font(.footnote)
                     }
+                    if let offset = BLEManager.shared.expectedSensorFetchOffsetString(for: storedDevice) {
+                        Text("Expected fetch offset: \(offset)")
+                            .foregroundColor(.secondary)
+                            .font(.footnote)
+                    }
 
                     HStack {
                         Spacer()

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -120,75 +120,180 @@ extension MainViewController {
         }
     }
     
-    // Dexcom BG Data Response processor
-    func ProcessDexBGData(data: [ShareGlucoseData], sourceName: String){
+    /// Processes incoming BG data.
+    func ProcessDexBGData(data: [ShareGlucoseData], sourceName: String) {
         let graphHours = 24 * UserDefaultsRepository.downloadDays.value
-        
-        if data.count == 0 {
+
+        guard !data.isEmpty else {
+            LogManager.shared.log(category: .nightscout, message: "No bg data received. Skipping processing.")
             return
         }
-        let latestDate = data[0].date
-        let now = dateTimeUtils.getNowTimeIntervalUTC()
-        
-        // Start the BG timer based on the reading
-        let secondsAgo = now - latestDate
-        
-        DispatchQueue.main.async {
-            if secondsAgo >= (20 * 60) {
-                TaskScheduler.shared.rescheduleTask(
-                    id: .fetchBG,
-                    to: Date().addingTimeInterval(5 * 60)
-                )
-            } else if secondsAgo >= (10 * 60) {
-                TaskScheduler.shared.rescheduleTask(
-                    id: .fetchBG,
-                    to: Date().addingTimeInterval(60)
-                )
-            } else if secondsAgo >= (7 * 60) {
-                TaskScheduler.shared.rescheduleTask(
-                    id: .fetchBG,
-                    to: Date().addingTimeInterval(30)
-                )
-            } else if secondsAgo >= (5 * 60) {
-                TaskScheduler.shared.rescheduleTask(
-                    id: .fetchBG,
-                    to: Date().addingTimeInterval(10)
-                )
-            } else {
-                let delay = (300 - secondsAgo + Double(UserDefaultsRepository.bgUpdateDelay.value))
-                TaskScheduler.shared.rescheduleTask(
-                    id: .fetchBG,
-                    to: Date().addingTimeInterval(delay)
-                )
 
-                if data.count > 1 {
-                    self.evaluateSpeakConditions(currentValue: data[0].sgv, previousValue: data[1].sgv)
+        let latestReading = data[0]
+        let sensorTimestamp = latestReading.date
+        let now = dateTimeUtils.getNowTimeIntervalUTC()
+        // secondsAgo is how old the newest reading is
+        let secondsAgo = now - sensorTimestamp
+
+        LogManager.shared.log(category: .nightscout,
+                              message: "Processing BG Data. Latest sensor reading: \(sensorTimestamp), now: \(now), secondsAgo: \(secondsAgo).",
+                              isDebug: true)
+
+        // Check if we have a new reading (i.e. sensor timestamp is greater than what we last saw).
+        if let lastTS = lastProcessedTimestamp {
+            if sensorTimestamp > lastTS {
+                let observedDelay = now - sensorTimestamp
+                addObservedDelay(observedDelay: observedDelay)
+                lastProcessedTimestamp = sensorTimestamp
+                LogManager.shared.log(category: .nightscout,
+                                      message: "New reading detected. Sensor time: \(sensorTimestamp) updated (was \(lastTS)). Observed delay: \(observedDelay) seconds.",
+                                      isDebug: true)
+            } else {
+                LogManager.shared.log(category: .nightscout,
+                                      message: "No new reading. Last processed sensor timestamp remains \(lastTS).",
+                                      isDebug: true)
+            }
+        } else {
+            lastProcessedTimestamp = sensorTimestamp
+            LogManager.shared.log(category: .nightscout,
+                                  message: "First reading processed. Sensor time: \(sensorTimestamp)",
+                                  isDebug: true)
+        }
+
+        // Compute a typical delay from our historical data.
+        let typicalDelay = computeOptimalDelay()
+
+        // Determine the next polling delay.
+        var delayToSchedule: Double = 0
+
+        DispatchQueue.main.async {
+            // Fallback scheduling for older readings.
+            if secondsAgo >= (20 * 60) {
+                delayToSchedule = 5 * 60
+                LogManager.shared.log(category: .nightscout,
+                                      message: "Reading is very old (\(secondsAgo) sec). Scheduling next fetch in 5 minutes.",
+                                      isDebug: true)
+            } else if secondsAgo >= (10 * 60) {
+                delayToSchedule = 60
+                LogManager.shared.log(category: .nightscout,
+                                      message: "Reading is moderately old (\(secondsAgo) sec). Scheduling next fetch in 60 seconds.",
+                                      isDebug: true)
+            } else if secondsAgo >= (7 * 60) {
+                delayToSchedule = 30
+                LogManager.shared.log(category: .nightscout,
+                                      message: "Reading is a bit old (\(secondsAgo) sec). Scheduling next fetch in 30 seconds.",
+                                      isDebug: true)
+            } else if secondsAgo >= (5 * 60) {
+                delayToSchedule = 5
+                LogManager.shared.log(category: .nightscout,
+                                      message: "Reading is clost to 5 minutes old (\(secondsAgo) sec). Scheduling next fetch in 10 seconds.",
+                                      isDebug: true)
+            } else {
+                // For fresh readings, predict when the next reading should appear.
+                // The sensor is scheduled to take a measurement every 300 seconds.
+                // Our base delay is: time remaining until 5 minutes from sensor timestamp + typical delay.
+                let baseDelay = 300 - secondsAgo + typicalDelay
+                delayToSchedule = baseDelay
+                LogManager.shared.log(category: .nightscout,
+                                      message: "Fresh reading. Base delay computed as: 300 - \(secondsAgo) + \(typicalDelay) = \(baseDelay) seconds.",
+                                      isDebug: true)
+
+                // Exploration: occasionally try polling earlier than expected.
+                let explorationRoll = Double.random(in: 0..<1)
+                // Chance (0.0–1.0) to try an earlier poll than predicted.
+                let explorationProbability: Double = 0.2
+
+                if explorationRoll < explorationProbability {
+                    // The absolute minimum delay we allow.
+                    let minDelay: Double = 3.0
+
+                    // How many seconds to subtract when doing an exploratory poll.
+                    let explorationOffset: Double = 1
+
+                    let exploredDelay = max(minDelay, baseDelay - explorationOffset)
+                    LogManager.shared.log(category: .nightscout,
+                                          message: "Exploration triggered. Adjusting delay from \(baseDelay) to \(exploredDelay) seconds.",
+                                          isDebug: true)
+                    delayToSchedule = exploredDelay
                 }
             }
+
+            // Log and schedule the next fetch.
+            LogManager.shared.log(category: .nightscout,
+                                  message: "Scheduling next BG fetch in \(delayToSchedule) seconds (at \(Date().addingTimeInterval(delayToSchedule))).",
+                                  isDebug: true)
+            TaskScheduler.shared.rescheduleTask(id: .fetchBG, to: Date().addingTimeInterval(delayToSchedule))
+
+            // Evaluate speak conditions if there is a previous value.
+            if data.count > 1 {
+                self.evaluateSpeakConditions(currentValue: data[0].sgv, previousValue: data[1].sgv)
+            }
         }
-        
+
+        // Process data for graph display.
         bgData.removeAll()
-        
-        // loop through the data so we can reverse the order to oldest first for the graph
         for i in 0..<data.count {
-            let dateString = data[data.count - 1 - i].date
-            if dateString >= dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) {
+            let readingTimestamp = data[data.count - 1 - i].date
+            if readingTimestamp >= dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) {
                 let sgvValue = data[data.count - 1 - i].sgv
-                
-                // Skip the current iteration if the sgv value is over 600
-                // First time a user starts a G7, they get a value of 4000
+
+                // Skip outlier values (e.g. first reading of a new sensor might be abnormally high).
                 if sgvValue > 600 {
+                    LogManager.shared.log(category: .nightscout,
+                                          message: "Skipping reading with sgv \(sgvValue) as it exceeds threshold.",
+                                          isDebug: true)
                     continue
                 }
-                
-                let reading = ShareGlucoseData(sgv: sgvValue, date: dateString, direction: data[data.count - 1 - i].direction)
+
+                let reading = ShareGlucoseData(sgv: sgvValue, date: readingTimestamp, direction: data[data.count - 1 - i].direction)
                 bgData.append(reading)
             }
         }
-        
+
+        LogManager.shared.log(category: .nightscout,
+                              message: "Graph data updated with \(bgData.count) entries.",
+                              isDebug: true)
         viewUpdateNSBG(sourceName: sourceName)
     }
-    
+
+    private func computeOptimalDelay() -> Double {
+        if Storage.shared.bgDelayDynamicEnabled.value {
+
+            guard let optimal = observedDelays.min() else {
+                LogManager.shared.log(category: .nightscout,
+                                      message: "No previous observed delays, starting with 10 seconds.",
+                                      isDebug: true)
+                return 10
+            }
+
+            LogManager.shared.log(category: .nightscout,
+                                  message: "Computed optimal delay from observations \(observedDelays) is \(optimal) seconds.",
+                                  isDebug: true)
+            return optimal
+        } else {
+            LogManager.shared.log(category: .nightscout,
+                                  message: "Dynamic bg delay is disabled, using user set value of \(UserDefaultsRepository.bgUpdateDelay.value) seconds.",
+                                  isDebug: true)
+            return Double(UserDefaultsRepository.bgUpdateDelay.value)
+        }
+    }
+
+    private func addObservedDelay(observedDelay : Double) {
+        guard observedDelay > 3, observedDelay < 45 else {
+            LogManager.shared.log(category: .nightscout,
+                                  message: "Observed delay of \(observedDelay) seconds is out of range, ignored.",
+                                  isDebug: true)
+            return
+        }
+
+        observedDelays.append(observedDelay)
+        
+        // Keep delays for the last hour
+        if observedDelays.count > 12 {
+            observedDelays.removeFirst()
+        }
+    }
+
     func updateServerText(with serverText: String? = nil) {
         if UserDefaultsRepository.showDisplayName.value, let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
             self.serverText.text = displayName

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -258,14 +258,14 @@ extension MainViewController {
 
     private func computeOptimalDelay() -> Double {
         if Storage.shared.bgDelayDynamicEnabled.value {
-
             guard let optimal = observedDelays.min() else {
                 LogManager.shared.log(category: .nightscout,
-                                      message: "No previous observed delays, starting with 10 seconds.",
+                                      message: "No previous observed delays, starting with \(Storage.shared.bgDelayDynamicDelay.value) seconds.",
                                       isDebug: true)
-                return 10
+                return Storage.shared.bgDelayDynamicDelay.value
             }
-
+            Storage.shared.bgDelayDynamicDelay.value = optimal
+            
             LogManager.shared.log(category: .nightscout,
                                   message: "Computed optimal delay from observations \(observedDelays) is \(optimal) seconds.",
                                   isDebug: true)

--- a/LoopFollow/Settings/AdvancedSettingsView.swift
+++ b/LoopFollow/Settings/AdvancedSettingsView.swift
@@ -22,9 +22,21 @@ struct AdvancedSettingsView: View {
                     Toggle("Graph Bolus", isOn: $viewModel.graphBolus)
                     Toggle("Graph Carbs", isOn: $viewModel.graphCarbs)
                     Toggle("Graph Other Treatments", isOn: $viewModel.graphOtherTreatments)
+                }
 
-                    Stepper(value: $viewModel.bgUpdateDelay, in: 1...30, step: 1) {
-                        Text("BG Update Delay (Sec): \(viewModel.bgUpdateDelay)")
+                Section(header: Text("BG Delay Settings")) {
+                    Toggle("Dynamic BG Delay", isOn: $viewModel.bgDelayDynamicEnabled)
+                    if viewModel.bgDelayDynamicEnabled {
+                        HStack {
+                            Text("Dynamic BG Delay (Sec)")
+                            Spacer()
+                            Text("\(viewModel.bgDelayDynamicDelay, specifier: "%.0f")")
+                                .foregroundColor(.secondary)
+                        }
+                    } else {
+                        Stepper(value: $viewModel.bgUpdateDelay, in: 1...30, step: 1) {
+                            Text("BG Update Delay (Sec): \(viewModel.bgUpdateDelay)")
+                        }
                     }
                 }
 

--- a/LoopFollow/Settings/AdvancedSettingsViewModel.swift
+++ b/LoopFollow/Settings/AdvancedSettingsViewModel.swift
@@ -44,11 +44,24 @@ class AdvancedSettingsViewModel: ObservableObject {
             UserDefaultsRepository.bgUpdateDelay.value = bgUpdateDelay
         }
     }
+
+    @Published var bgDelayDynamicEnabled: Bool {
+        didSet {
+            Storage.shared.bgDelayDynamicEnabled.value = bgDelayDynamicEnabled
+        }
+    }
+    @Published var bgDelayDynamicDelay: Double {
+        didSet {
+            Storage.shared.bgDelayDynamicDelay.value = bgDelayDynamicDelay
+        }
+    }
+
     @Published var debugLogLevel: Bool {
         didSet {
             Storage.shared.debugLogLevel.value = debugLogLevel
         }
     }
+
     init() {
         self.downloadTreatments = UserDefaultsRepository.downloadTreatments.value
         self.downloadPrediction = UserDefaultsRepository.downloadPrediction.value
@@ -57,6 +70,8 @@ class AdvancedSettingsViewModel: ObservableObject {
         self.graphCarbs = UserDefaultsRepository.graphCarbs.value
         self.graphOtherTreatments = UserDefaultsRepository.graphOtherTreatments.value
         self.bgUpdateDelay = UserDefaultsRepository.bgUpdateDelay.value
+        self.bgDelayDynamicEnabled = Storage.shared.bgDelayDynamicEnabled.value
+        self.bgDelayDynamicDelay = Storage.shared.bgDelayDynamicDelay.value
         self.debugLogLevel = Storage.shared.debugLogLevel.value
     }
 }

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -37,6 +37,8 @@ class Storage {
 
     var debugLogLevel = StorageValue<Bool>(key: "debugLogLevel", defaultValue: false)
 
+    var bgDelayDynamicEnabled = StorageValue<Bool>(key: "bgDelayDynamicEnabled", defaultValue: false)
+    var bgDelayDynamicDelay = StorageValue<Double>(key: "bgDelayDynamicDelay", defaultValue: 10)
 
     static let shared = Storage()
 

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -40,6 +40,8 @@ class Storage {
     var bgDelayDynamicEnabled = StorageValue<Bool>(key: "bgDelayDynamicEnabled", defaultValue: false)
     var bgDelayDynamicDelay = StorageValue<Double>(key: "bgDelayDynamicDelay", defaultValue: 10)
 
+    var sensorScheduleOffset = StorageValue<Double?>(key: "sensorScheduleOffset", defaultValue: nil)
+
     static let shared = Storage()
 
     private init() { }

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -149,6 +149,12 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     /// Historical delays observed (in seconds) between sensor measurement and our fetch.
     var observedDelays: [Double] = []
 
+    /// If last fetch did not generate new bg data, we regard it an too early fetch
+    var lastBgFetchMiss: Bool = false
+
+    /// If last fetch did not generate new bg data, we regard it an too early fetch
+    var lastBgFetchDelay: Double?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -143,6 +143,12 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
 
     let contactImageUpdater = ContactImageUpdater()
 
+    /// The timestamp (seconds since reference) of the last processed sensor reading.
+    var lastProcessedTimestamp: TimeInterval?
+
+    /// Historical delays observed (in seconds) between sensor measurement and our fetch.
+    var observedDelays: [Double] = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
# Dynamic BG Delay

## Summary
This change implements an dynamic mechanism to calculate the delay between when a BG value is generated by the sensor and when it is available from Dexcom or Nightscout. The goal is to minimize the update delay in LoopFollow while avoiding unnecessary fetches.

## Changes
- Added dynamic delay calculation based on observed sensor-to-upload delays.
- Updated BG data processing to update the delay estimate only when a new reading is detected.
- Refactored settings to include a new "Dynamic BG Delay" option with a read-only display of the current dynamic delay.
- Moved BG delay settings into their own section, hiding the static setting when dynamic mode is enabled.
- Implemented logging for delay estimation debugging.

## Testing
Verified with real life data that the dynamic delay adapts as expected and that the settings UI reflects the current mode and delay.