### PR TITLE
Predictions for released version of Trio

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -159,10 +159,22 @@ extension MainViewController {
                 infoManager.updateInfoData(type: .tdd, value: tddMetric)
             }
 
+
+            let predBGsData: [String: AnyObject]? = {
+                if let enacted = lastLoopRecord["suggested"] as? [String: AnyObject],
+                   let predBGs = enacted["predBGs"] as? [String: AnyObject] {
+                    return predBGs
+                } else if let suggested = lastLoopRecord["enacted"] as? [String: AnyObject],
+                          let predBGs = suggested["predBGs"] as? [String: AnyObject] {
+                    return predBGs
+                }
+                return nil
+            }()
+
             let predictioncolor = UIColor.systemGray
             PredictionLabel.textColor = predictioncolor
             topPredictionBG = UserDefaultsRepository.minBGScale.value
-            if let predbgdata = enactedOrSuggested["predBGs"] as? [String: AnyObject] {
+            if let predbgdata = predBGsData {
                 let predictionTypes: [(type: String, colorName: String, dataIndex: Int)] = [
                     ("ZT", "ZT", 12),
                     ("IOB", "Insulin", 13),


### PR DESCRIPTION
Fix for a bug introduced in v2.2.9.
This restores proper display of predictions for released version of Trio, Trio 0.2.3 and earlier.
See Issue #371 for details.