### PR TITLE
Task improvements

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -86,6 +86,7 @@ extension MainViewController {
 
         if jsonDeviceStatus.count == 0 {
             LogManager.shared.log(category: .deviceStatus, message: "Device status is empty")
+            TaskScheduler.shared.rescheduleTask(id: .deviceStatus, to: Date().addingTimeInterval(5 * 60))
             return
         }
         

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -107,7 +107,7 @@ class TaskScheduler {
                 continue
             }
 
-            // Check if we should skip alarmCheck
+            // Check if we should re-schedule alarmCheck till after other tasks are done
             if taskID == .alarmCheck {
                 let shouldSkip = tasksToSkipAlarmCheck.contains {
                     guard let checkTask = tasks[$0] else { return false }
@@ -115,7 +115,14 @@ class TaskScheduler {
                 }
 
                 if shouldSkip {
-                    //LogManager.shared.log(category: .taskScheduler, message: "Skipping alarmCheck because one of the specified tasks is due or set to distant future.")
+                    //LogManager.shared.log(category: .taskScheduler, message: "Skipping alarmCheck because one of the specified tasks is due or set to distant future.", isDebug: true)
+
+                    guard var existingTask = self.tasks[taskID] else {
+                        continue
+                    }
+                    existingTask.nextRun = Date().addingTimeInterval(5)
+                    self.tasks[taskID] = existingTask
+
                     continue
                 }
             }


### PR DESCRIPTION
### Improvements

- **Throttled Scheduling:**  
  Background refresh notifications are now re-scheduled at most once every 10 seconds, preventing intensive calls to this functionality.

- **Device Status Retry:**  
  When device status returns empty, the system now retries after 5 minutes instead of giving up immediately.

- **Alarm Check Delay:**  
  Alarm check tasks now wait 5 seconds after `.deviceStatus`, `.treatments`, and `.fetchBG` are complete before re-attempting, avoiding immediate re-triggers.