### PR TITLE
Adjust ISF Unit Detection Threshold from 15 to 16

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -47,7 +47,7 @@ extension MainViewController {
             var enactedISF: HKQuantity?
             if let enactedISFValue = enactedOrSuggested["ISF"] as? Double {
                 var determinedISFUnit: HKUnit = .milligramsPerDeciliter
-                if enactedISFValue < 15 {
+                if enactedISFValue < 16 {
                     determinedISFUnit = .millimolesPerLiter
                 }
                 enactedISF = HKQuantity(unit: determinedISFUnit, doubleValue: enactedISFValue)


### PR DESCRIPTION
**Summary**

This PR updates the threshold for dynamically detecting the ISF (Insulin Sensitivity Factor) unit from 15 to 16.

**Background**

ISF does not always use the unit from the profile. If there is an override affecting ISF, it is reported in mg/dL/unit instead of the profile’s default unit.

**Change Details**
	•	Previously, ISF values up to 15 were detected as mmol/L/unit (≈ 0.83 mmol/L/unit).
	•	With this change, ISF values up to 16 will now be detected as mmol/L/unit (≈ 0.89 mmol/L/unit).

**Rationale**

This adjustment allows for slightly higher ISF values to still be interpreted as mmol/L/unit.