### PR TITLE
Skip task scheduler logging

### DIFF
--- a/LoopFollow/Log/LogManager.swift
+++ b/LoopFollow/Log/LogManager.swift
@@ -63,6 +63,10 @@ class LogManager {
         consoleQueue.async {
             print(logMessage)
         }
+        
+        if category == .taskScheduler && isDebug {
+            return
+        }
 
         if let key = limitIdentifier, !Storage.shared.debugLogLevel.value {
             let shouldLog: Bool = rateLimitQueue.sync {


### PR DESCRIPTION
Task scheduler does write a lot to the debug log, this change ignores those log rows attempts - they are still visible in the debug console when debugging from xcode. We might want to add a toggle for it in the future.