### PR TITLE
disable keepalive-workflow because the repo is no longer available

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -169,7 +169,7 @@ jobs:
       # Keep repository "alive": add empty commits to ALIVE_BRANCH after "time_elapsed" days of inactivity to avoid inactivation of scheduled workflows
       - name: Keep alive
         run: |
-          echo "Keep Alive is temporarily removed" 
+          echo "Keep Alive is no longer available" 
       #  if: |
       #    needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
       #    (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')

--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -168,12 +168,14 @@ jobs:
 
       # Keep repository "alive": add empty commits to ALIVE_BRANCH after "time_elapsed" days of inactivity to avoid inactivation of scheduled workflows
       - name: Keep alive
-        if: |
-          needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-          (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-        uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
-        with:
-          time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
+        run: |
+          echo "Keep Alive is temporarily removed" 
+      #  if: |
+      #    needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
+      #    (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
+      #  uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
+      #  with:
+      #    time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
 
       - name: Show scheduled build configuration message
         if: needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION != 'true'


### PR DESCRIPTION
## Purpose

The `gautamkrishnar/keepalive-workflow` has been taken down by GitHub. ~~We do not know if this is permanent or not.~~ We now know this is a permanent change.
This PR makes a minimal change to the current build_LoopFollow.yml which renables building with GitHub actions.

## Method

Comment out the section that is not available and insert an echo for the log file.

At a later time, the whole logic thread for automatic build will be reviewed, updated and documented.

## Testing

This was copied from the LoopWorkspace change and requires test.