### PR TITLE
Fix for Loop indefinite overrides

### DIFF
--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -38,7 +38,13 @@ extension MainViewController {
             else { continue }
 
             let start = max(startDate.timeIntervalSince1970, graphHorizon)
-            var end   = start + (e["duration"] as? Double ?? 5) * 60   // seconds
+
+            var end: TimeInterval
+            if (e["durationType"] as? String) == "indefinite" { // Only for Loop overrides
+                end = maxEndDate
+            } else {
+                end = start + (e["duration"] as? Double ?? 5) * 60
+            }
 
             if i + 1 < sorted.count,
                let nextDateStr = (sorted[i + 1]["timestamp"] as? String) ?? (sorted[i + 1]["created_at"] as? String),


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/loopandlearn/LoopFollow/pull/400, where indefinite overrides created by Loop were incorrectly displayed as 5-minute events until they ended. Once terminated, they were updated with the correct duration and rendered properly.

With this fix, indefinite overrides are now shown correctly from the start.