### PR TITLE
Fix crash when ShareClient returns nil result without error

### DIFF
--- a/LoopFollow/Extensions/ShareClientExtension.swift
+++ b/LoopFollow/Extensions/ShareClientExtension.swift
@@ -13,7 +13,7 @@ public struct ShareGlucoseData: Decodable {
     var sgv: Int
     var date: TimeInterval
     var direction: String?
-
+    
     enum CodingKeys: String, CodingKey {
         case sgv  // Sensor Blood Glucose
         case mbg  // Manual Blood Glucose
@@ -21,7 +21,7 @@ public struct ShareGlucoseData: Decodable {
         case date
         case direction
     }
-
+    
     // Decoder initializer for handling JSON data
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -35,12 +35,12 @@ public struct ShareGlucoseData: Decodable {
         } else {
             throw DecodingError.dataCorruptedError(forKey: .sgv, in: container, debugDescription: "Expected to decode Double for sgv, mbg or glucose.")
         }
-    
+        
         // Decode the date and optional direction
         date = try container.decode(TimeInterval.self, forKey: .date)
         direction = try container.decodeIfPresent(String.self, forKey: .direction)
     }
-
+    
     public init(sgv: Int, date: TimeInterval, direction: String?) {
         self.sgv = sgv
         self.date = date
@@ -49,45 +49,44 @@ public struct ShareGlucoseData: Decodable {
 }
 
 private var TrendTable: [String] = [
-   "NONE",             // 0
-   "DoubleUp",         // 1
-   "SingleUp",         // 2
-   "FortyFiveUp",      // 3
-   "Flat",             // 4
-   "FortyFiveDown",    // 5
-   "SingleDown",       // 6
-   "DoubleDown",       // 7
-   "NOT COMPUTABLE",   // 8
-   "RATE OUT OF RANGE" // 9
+    "NONE",             // 0
+    "DoubleUp",         // 1
+    "SingleUp",         // 2
+    "FortyFiveUp",      // 3
+    "Flat",             // 4
+    "FortyFiveDown",    // 5
+    "SingleDown",       // 6
+    "DoubleDown",       // 7
+    "NOT COMPUTABLE",   // 8
+    "RATE OUT OF RANGE" // 9
 ]
 
 // TODO: probably better to make this an inherited class rather than an extension
 extension ShareClient {
-
+    
     public func fetchData(_ entries: Int, callback: @escaping (ShareError?, [ShareGlucoseData]?) -> Void) {
         
         self.fetchLast(entries) { (error, result) -> () in
-            guard error == nil || result != nil else {
-                return callback(error, nil)
+            guard error == nil, let result = result else {
+                return callback(error ?? .fetchError, nil)
             }
             
             // parse data to conanical form
             var shareData = [ShareGlucoseData]()
-            for i in 0..<result!.count {
-                
-                var trend = Int(result![i].trend)
-                if(trend < 0 || trend > TrendTable.count-1) {
+            for item in result {
+                var trend = Int(item.trend)
+                if trend < 0 || trend >= TrendTable.count {
                     trend = 0
                 }
-            
+                
                 let newShareData = ShareGlucoseData(
-                    sgv: Int(result![i].glucose),
-                    date: result![i].timestamp.timeIntervalSince1970,
+                    sgv: Int(item.glucose),
+                    date: item.timestamp.timeIntervalSince1970,
                     direction: TrendTable[trend]
                 )
                 shareData.append(newShareData)
             }
-            callback(nil,shareData)
-         }
+            callback(nil, shareData)
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a crash in `ShareClient.fetchData` that occurred when the `fetchLast` method returned both `error == nil` and `result == nil`. The original guard clause allowed this case to pass, leading to a force unwrap on `result!`, which caused a runtime crash (`EXC_BREAKPOINT` / `SIGTRAP`).

## Changes

- Updated the guard clause in `fetchData` to only proceed when both `error == nil` and `result != nil`.
- Replaced force-unwraps of `result![i]` with direct usage of the loop variable `item` for safer and cleaner code.

## Impact

This change prevents crashes when Dexcom Share responds with an unexpected empty payload or malformed data, ensuring the app gracefully handles and logs the error instead.