### PR TITLE
Support for Trio External Insulin Display

### DIFF
--- a/LoopFollow/Controllers/Nightscout/Treatments.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments.swift
@@ -60,7 +60,7 @@ extension MainViewController {
             switch eventType {
             case "Temp Basal":
                 tempBasal.append(entry)
-            case "Correction Bolus", "Bolus":
+            case "Correction Bolus", "Bolus", "External Insulin":
                 if let automatic = entry["automatic"] as? Bool, automatic {
                     smb.append(entry)
                 } else {


### PR DESCRIPTION
Adds support for displaying insulin treatments with event type "External Insulin", enabling LoopFollow to show externally injected insulin alongside manual boluses.