### PR TITLE
Dexcom empty data guard

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -24,8 +24,8 @@ extension MainViewController {
                 return
             }
 
-            guard let data = result else {
-                LogManager.shared.log(category: .dexcom, message: "Received nil data from Dexcom", limitIdentifier: "Received nil data from Dexcom")
+            guard let data = result, !data.isEmpty else {
+                LogManager.shared.log(category: .dexcom, message: "Received empty data array from Dexcom", limitIdentifier: "Received empty data array from Dexcom")
                 self.webLoadNSBGData()
                 return
             }


### PR DESCRIPTION
#### What & Why
`dexShare?.fetchData()` could return an empty array even when the network call succeeds.  
Our previous guard only checked for `nil`, so subscripting `data[0]` would crash with “index out of range”.

#### Changes
* Extend the guard clause to `guard let data = result, !data.isEmpty`  
* Update the log message to “Received empty data array from Dexcom” for clarity.

#### How to test
1. Point the Dexcom share stub/service at a response that returns `[]`.
2. Launch the app and trigger a download.
3. Verify:
   * No crash occurs.  
   * Log output shows the new message.  
   * The fallback to `webLoadNSBGData()` is executed.

#### Notes
No functional changes beyond the safety check.