### PR TITLE
RemoteViewController: suppress duplicate @Published emissions to stop…

### DIFF
--- a/LoopFollow/Remote/RemoteViewController.swift
+++ b/LoopFollow/Remote/RemoteViewController.swift
@@ -21,8 +21,8 @@ class RemoteViewController: UIViewController {
         super.viewDidLoad()
 
         cancellable = Publishers.CombineLatest(
-            Storage.shared.remoteType.$value,
-            ObservableUserDefaults.shared.device.$value
+            Storage.shared.remoteType.$value.removeDuplicates(),
+            ObservableUserDefaults.shared.device.$value.removeDuplicates()
         )
         .sink { [weak self] newRemoteType, newDevice in
             DispatchQueue.main.async {


### PR DESCRIPTION
### What does this PR do?
Rebuilds of **`RemoteViewController`** were triggered every time `remoteType` or `device` was **re-assigned**—even when the value didn’t actually change—because `@Published` emits on every write.  
That tore down the `NavigationView` and pushed users back to the root screen, so Bolus/Meal/Temp Target windows closed unexpectedly.

### Fix
Adds `.removeDuplicates()` to both publishers in the `CombineLatest` chain.  
Identical values are now filtered out, so `updateView()` runs only when the user genuinely switches Remote Type or Device.

### User-visible impact
* Bolus, Meal, Temp Target, and Overrides screens stay open; no more spontaneous “pop”.
* No change in behaviour when the user **actually** changes the setting.

### Reference / evidence
* Facebook report by **Muntean George** (Trio: DIY Diabetes App Support group).  
* GitHub issue **#404** “Trio Remote Control – Temp Target screen timeout”.

### Tested
1. Open Bolus screen and wait 10 minutes → stays on screen.  
2. Change Remote Type in Settings → screen refreshes as before.