### PR TITLE
remove --3way and add pauses

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -34,14 +34,19 @@ update_follower () {
   echo; echo "🔄  Updating $DIR …"
   cd "$DIR"
 
+  echo; echo "If there are custom changes needed to the patch, make the change before continuing"
+  pause
+
   # 1 · Make sure we’re on a clean, up-to-date main
   echo_run git switch "$MAIN_BRANCH"
   echo_run git fetch
   echo_run git pull
 
-  # 2 · Apply the patch with 3-way fallback
-  if ! git apply --3way  --whitespace=nowarn "$PATCH_FILE"; then
+  # 2 · Apply the patch. Do not use 3way because commit history is not in common
+  if ! git apply --whitespace=nowarn "$PATCH_FILE"; then
     echo "‼️  Some hunks could not be merged automatically."
+    echo; echo "Use a different terminal to fix files before continuing"
+    pause
   fi
 
   # 3 · Pause if any conflict markers remain


### PR DESCRIPTION
Removed the `--3way` flag for `git apply` in update_follower. That is not appropriate when the commit history is not common between repositories.

Add extra pauses to enable the developer doing the release to handle specific differences between LoopFollow and the _Second and _Third repositories.