### PR TITLE
Auto-scroll to selected tone in picker

### DIFF
--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmAudioSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmAudioSection.swift
@@ -96,32 +96,38 @@ private struct TonePickerSheet: View {
 
     var body: some View {
         NavigationView {
-            List {
-                ForEach(SoundFile.allCases) { tone in
-                    Button {
-                        selected = tone
-                        AlarmSound.setSoundFile(str: tone.rawValue)
-                        AlarmSound.stop()
-                        AlarmSound.playTest()
-                    } label: {
-                        HStack {
-                            Text(tone.displayName)
-                            if tone == selected {
-                                Spacer()
-                                Image(systemName: "checkmark")
-                                    .foregroundColor(.accentColor)
+            ScrollViewReader { proxy in
+                List {
+                    ForEach(SoundFile.allCases) { tone in
+                        Button {
+                            selected = tone
+                            AlarmSound.setSoundFile(str: tone.rawValue)
+                            AlarmSound.stop()
+                            AlarmSound.playTest()
+                        } label: {
+                            HStack {
+                                Text(tone.displayName)
+                                if tone == selected {
+                                    Spacer()
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.accentColor)
+                                }
                             }
+                        }
+                        .id(tone)
+                    }
+                }
+                .navigationTitle("Choose Tone")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            AlarmSound.stop()
+                            dismiss()
                         }
                     }
                 }
-            }
-            .navigationTitle("Choose Tone")
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        AlarmSound.stop()
-                        dismiss()
-                    }
+                .onAppear {
+                    proxy.scrollTo(selected, anchor: .center)
                 }
             }
         }


### PR DESCRIPTION
This pull request addresses a minor UX issue where the selection screen wouldn't automatically focus on the currently selected tone, as the list always displayed from the top.

### Background

As Lauren Kristie pointed out:
> "When I pick an alarm sound, it auto scrolls to the top of the list. So if I’m looking for one I like for that alarm, I have to scroll back down to it."

This required users to manually scroll to find their currently selected tone if it was not visible at the top of the list.

### Changes

To fix this, the `TonePickerSheet` has been updated:
* The `List` is now wrapped in a **`ScrollViewReader`**.
* An **`.onAppear`** modifier has been added to the `List` to programmatically scroll to the currently selected tone when the view loads.
* The scroll anchor is set to **`.center`** to ensure the selected item is clearly visible.

This creates a smoother and more intuitive user experience, directly addressing the feedback. 🎵