### PR TITLE
Implement Secure Inputs for Dexcom and Nightscout Credentials

### DIFF
--- a/LoopFollow/Nightscout/NightscoutSettingsView.swift
+++ b/LoopFollow/Nightscout/NightscoutSettingsView.swift
@@ -25,35 +25,33 @@ struct NightscoutSettingsView: View {
     // MARK: - Subviews / Computed Properties
 
     private var urlSection: some View {
-        Section {
-            TextField("URL", text: $viewModel.nightscoutURL)
+        Section(header: Text("URL")) {
+            TextField("Enter URL", text: $viewModel.nightscoutURL)
                 .textContentType(.URL)
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
                 .onChange(of: viewModel.nightscoutURL) { newValue in
                     viewModel.processURL(newValue)
                 }
-        } header: {
-            Text("URL")
         }
     }
 
     private var tokenSection: some View {
-        Section {
-            TextField("Token", text: $viewModel.nightscoutToken)
-                .textContentType(.password)
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
-        } header: {
-            Text("Token")
+        Section(header: Text("Token")) {
+            HStack {
+                Text("Access Token")
+                TogglableSecureInput(
+                    placeholder: "Enter Token",
+                    text: $viewModel.nightscoutToken,
+                    style: .singleLine
+                )
+            }
         }
     }
 
     private var statusSection: some View {
-        Section {
+        Section(header: Text("Status")) {
             Text(viewModel.nightscoutStatus)
-        } header: {
-            Text("Status")
         }
     }
 }

--- a/LoopFollow/Settings/DexcomSettingsView.swift
+++ b/LoopFollow/Settings/DexcomSettingsView.swift
@@ -11,13 +11,22 @@ struct DexcomSettingsView: View {
         NavigationView {
             Form {
                 Section(header: Text("Dexcom Settings")) {
-                    TextField("User Name", text: $viewModel.userName)
-                        .autocapitalization(.none)
-                        .disableAutocorrection(true)
+                    HStack {
+                        Text("User Name")
+                        TextField("Enter User Name", text: $viewModel.userName)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .multilineTextAlignment(.trailing)
+                    }
 
-                    TextField("Password", text: $viewModel.password)
-                        .autocapitalization(.none)
-                        .disableAutocorrection(true)
+                    HStack {
+                        Text("Password")
+                        TogglableSecureInput(
+                            placeholder: "Enter Password",
+                            text: $viewModel.password,
+                            style: .singleLine
+                        )
+                    }
 
                     Picker("Server", selection: $viewModel.server) {
                         Text("US").tag("US")


### PR DESCRIPTION
### PR: Implement Secure Inputs for Dexcom and Nightscout Credentials

**Closes #417**

#### Description

This pull request addresses the issue of sensitive credentials (Dexcom password and Nightscout token) being displayed in plain text in the settings views. To enhance security and user privacy, the standard `TextField` has been replaced with the existing `TogglableSecureInput` component for these fields.

#### Changes Made

1.  **`DexcomSettingsView.swift`**:
    * Replaced the `TextField` for the password with `TogglableSecureInput`.
    * Wrapped the "User Name" and "Password" rows in `HStack`s for consistent UI alignment.

2.  **`NightscoutSettingsView.swift`**:
    * Replaced the `TextField` for the "Access Token" with `TogglableSecureInput`.
    * Updated the layout to use an `HStack` for better alignment of the label and the input field.
    * Changed the label from "Token" to "Access Token" for clarity.

#### Impact

* **Improved Security**: Passwords and tokens are now masked by default, preventing them from being accidentally exposed.
* **Enhanced User Experience**: Users can toggle the visibility of the credentials using the familiar "eye" icon, providing both security and convenience.
* **Code Consistency**: Leverages an existing custom component (`TogglableSecureInput`) for a consistent approach to handling secrets across the app.

This resolves the concerns raised in issue #417 by ensuring all sensitive credential fields are properly secured.