### PR TITLE
Clear override text conditionally based on device

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -72,7 +72,7 @@ extension MainViewController {
 
     // NS Device Status Response Processor
     func updateDeviceStatusDisplay(jsonDeviceStatus: [[String: AnyObject]]) {
-        infoManager.clearInfoData(types: [.iob, .cob, .override, .battery, .pump, .target, .isf, .carbRatio, .updated, .recBolus, .tdd])
+        infoManager.clearInfoData(types: [.iob, .cob, .battery, .pump, .target, .isf, .carbRatio, .updated, .recBolus, .tdd])
 
         // For Loop, clear the current override here - For Trio, it is handled using treatments
         if Storage.shared.device.value == "Loop" {

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -74,6 +74,11 @@ extension MainViewController {
     func updateDeviceStatusDisplay(jsonDeviceStatus: [[String: AnyObject]]) {
         infoManager.clearInfoData(types: [.iob, .cob, .override, .battery, .pump, .target, .isf, .carbRatio, .updated, .recBolus, .tdd])
 
+        // For Loop, clear the current override here - For Trio, it is handled using treatments
+        if Storage.shared.device.value == "Loop" {
+            infoManager.clearInfoData(types: [.override])
+        }
+
         if jsonDeviceStatus.count == 0 {
             LogManager.shared.log(category: .deviceStatus, message: "Device status is empty")
             TaskScheduler.shared.rescheduleTask(id: .deviceStatus, to: Date().addingTimeInterval(5 * 60))


### PR DESCRIPTION
This pull request resolves issue #403.

**Description:**

This change introduces a conditional clearing of the override information in the `infoManager`. Previously, the override data was cleared every time the device status was updated.

This caused an issue for Trio users, where the override text would disappear from the display. This happened because for Trio, override information is fetched from treatments, and the device status does not contain this data. If a device status update occurred after the treatment data was processed, the override information would be incorrectly cleared.

For "Loop" devices, the override information *is* part of the device status, so clearing it upon refresh is the correct behavior to ensure the display is up-to-date.

**Changes:**

- In `updateDeviceStatusDisplay(jsonDeviceStatus:)`, the call to `infoManager.clearInfoData(types: [.override])` is now wrapped in a conditional check.
- The override data is now only cleared if the selected device is "Loop".

This ensures that the override information is handled correctly for both Loop and Trio users, fixing the glitch where the override text would intermittently disappear for the latter.