### PR TITLE
Fix: Honor the global "Snooze All" setting

### DIFF
--- a/LoopFollow/Alarm/AlarmManager.swift
+++ b/LoopFollow/Alarm/AlarmManager.swift
@@ -43,6 +43,17 @@ class AlarmManager {
     func checkAlarms(data: AlarmData) {
         let now = Date()
         var alarmTriggered = false
+
+        let config = Storage.shared.alarmConfiguration.value
+
+        // Honor the "Snooze All" setting. If active, stop any current alarm and exit.
+        if let snoozeUntil = config.snoozeUntil, snoozeUntil > now {
+            if Observable.shared.currentAlarm.value != nil {
+                stopAlarm()
+            }
+            return
+        }
+
         let alarms = Storage.shared.alarms.value
 
         let sorted = alarms.sorted(by: Alarm.byPriorityThenSpec)


### PR DESCRIPTION
## Description

This PR fixes a bug where the **"Snooze All"** setting was not being honored. Alarms would continue to trigger even after the global snooze was activated from the settings screen.

The `checkAlarms` function now correctly checks for the global `snoozeUntil` configuration at the very beginning. If snoozing is active, it will stop any current alarm and exit immediately, ensuring no new alarms are triggered until the snooze period is over.

A big thank you to **Daniel Mini Johansson** for reporting this issue! ✨