### PR TITLE
Improve initial setup and UI reactivity

### DIFF
--- a/LoopFollow/Settings/SettingsMenuView.swift
+++ b/LoopFollow/Settings/SettingsMenuView.swift
@@ -6,9 +6,9 @@ import SwiftUI
 import UIKit
 
 struct SettingsMenuView: View {
-    // MARK: – Call-backs
+    // MARK: - Observed Objects
 
-    let onNightscoutVisibilityChange: (_ enabled: Bool) -> Void
+    @ObservedObject private var nightscoutURL = Storage.shared.url
 
     // MARK: – Local state
 
@@ -45,7 +45,7 @@ struct SettingsMenuView: View {
                         path.append(Sheet.graph)
                     }
 
-                    if IsNightscoutEnabled() {
+                    if !nightscoutURL.value.isEmpty {
                         NavigationRow(title: "Information Display Settings",
                                       icon: "info.circle")
                         {
@@ -153,9 +153,6 @@ struct SettingsMenuView: View {
             {
                 path.append(Sheet.dexcom)
             }
-        }
-        .onAppear {
-            onNightscoutVisibilityChange(IsNightscoutEnabled())
         }
     }
 

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -11,7 +11,7 @@ import UIKit
  */
 
 class Storage {
-    var remoteType = StorageValue<RemoteType>(key: "remoteType", defaultValue: .nightscout)
+    var remoteType = StorageValue<RemoteType>(key: "remoteType", defaultValue: .none)
     var deviceToken = StorageValue<String>(key: "deviceToken", defaultValue: "")
     var expirationDate = StorageValue<Date?>(key: "expirationDate", defaultValue: nil)
     var sharedSecret = StorageValue<String>(key: "sharedSecret", defaultValue: "")

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -291,6 +291,13 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             }
             .store(in: &cancellables)
 
+        Storage.shared.url.$value
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                self?.tabBarController?.tabBar.items?[3].isEnabled = !value.isEmpty
+            }
+            .store(in: &cancellables)
+
         updateQuickActions()
 
         speechSynthesizer.delegate = self

--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -16,10 +16,7 @@ final class SettingsViewController: UIViewController {
         super.viewDidLoad()
 
         // Build SwiftUI menu
-        host = UIHostingController(
-            rootView: SettingsMenuView { [weak self] nightscoutEnabled in
-                self?.tabBarController?.tabBar.items?[3].isEnabled = nightscoutEnabled
-            })
+        host = UIHostingController(rootView: SettingsMenuView())
 
         // Dark-mode override
         if Storage.shared.forceDarkMode.value {


### PR DESCRIPTION
### Fix: Improve initial setup and UI reactivity

This pull request resolves a couple of issues to create a smoother experience for first-time users. It introduces dynamic UI updates and sets more sensible defaults.

#### Changes

* **Dynamic Nightscout Features:** When a user enters a Nightscout URL in the settings, all related UI elements (like "Information Display Settings," and "Remote Settings") now become enabled **immediately** without requiring an app restart. This is achieved by making the `SettingsMenuView` reactive to changes in the stored URL using `@ObservedObject`.
* **Default Remote Type:** The default `remoteType` for new users has been changed from `.nightscout` to `.none`. This ensures that alarm settings are available as a tab by default until a user explicitly configures remote commands.