### PR TITLE
Optimize RemoteViewController updates and refresh view on tab selection

### DIFF
--- a/LoopFollow/Remote/RemoteViewController.swift
+++ b/LoopFollow/Remote/RemoteViewController.swift
@@ -7,20 +7,19 @@ import SwiftUI
 import UIKit
 
 class RemoteViewController: UIViewController {
-    private var cancellables = Set<AnyCancellable>()
+    private var cancellable: AnyCancellable?
     private var hostingController: UIHostingController<AnyView>?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        Storage.shared.device.$value
+        cancellable = Storage.shared.device.$value
             .removeDuplicates()
             .sink { [weak self] _ in
                 DispatchQueue.main.async {
                     self?.updateView()
                 }
             }
-            .store(in: &cancellables)
     }
 
     private func updateView() {
@@ -92,6 +91,6 @@ class RemoteViewController: UIViewController {
     }
 
     deinit {
-        cancellables.forEach { $0.cancel() }
+        cancellable?.cancel()
     }
 }


### PR DESCRIPTION
## Summary
Improves the RemoteViewController's update mechanism by optimizing unnecessary subscriptions and ensuring the view refreshes when the tab is selected.

## Changes Made

### 1. Optimized Publisher Subscriptions
- **Removed** subscription to `Storage.shared.remoteType.$value` - since remote type changes only happen in the settings tab, this view will now naturally re-render when switching back to the remote tab
- **Kept** subscription to `Storage.shared.device.$value` - device changes can affect the current view and should trigger updates
- **Simplified** from `CombineLatest` to single publisher subscription

### 2. Added View Refresh on Tab Selection
- **Added** `viewWillAppear(_:)` override to call `updateView()` when the tab is selected
- **Removed** `updateView()` call from `viewDidLoad()` to avoid redundant initial render

### 3. Code Cleanup
- **Removed** unused imports (`Foundation`, `HealthKit`)

## Benefits
- **Reduced unnecessary re-renders** - no longer re-renders when remote type changes in other tabs
- **Improved user experience** - view always refreshes when tab is selected, ensuring up-to-date content and proper appearance updates
- **Cleaner code** - removed unused imports and redundant operations

## Testing
- Confirm view refreshes when switching to remote tab from other tabs