### PR TITLE
feat: add user-configurable tab customization for tabs 2 and 4

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		DD16AF112C997B4600FB655A /* LoadingButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD16AF102C997B4600FB655A /* LoadingButtonView.swift */; };
 		DD1A97142D4294A5000DDC11 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A97132D4294A4000DDC11 /* AdvancedSettingsView.swift */; };
 		DD1A97162D4294B3000DDC11 /* AdvancedSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A97152D4294B2000DDC11 /* AdvancedSettingsViewModel.swift */; };
+		DD1D52922E1D9E8200432050 /* TabSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D52912E1D9E8200432050 /* TabSelection.swift */; };
+		DD1D52942E1DA31000432050 /* TabCustomizationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D52932E1DA31000432050 /* TabCustomizationSettingsView.swift */; };
 		DD2C2E4F2D3B8AF1006413A5 /* NightscoutSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2C2E4E2D3B8AEC006413A5 /* NightscoutSettingsView.swift */; };
 		DD2C2E512D3B8B0C006413A5 /* NightscoutSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2C2E502D3B8B0B006413A5 /* NightscoutSettingsViewModel.swift */; };
 		DD2C2E542D3C37DC006413A5 /* DexcomSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2C2E532D3C37D7006413A5 /* DexcomSettingsViewModel.swift */; };
@@ -415,6 +417,8 @@
 		DD16AF102C997B4600FB655A /* LoadingButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingButtonView.swift; sourceTree = "<group>"; };
 		DD1A97132D4294A4000DDC11 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		DD1A97152D4294B2000DDC11 /* AdvancedSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsViewModel.swift; sourceTree = "<group>"; };
+		DD1D52912E1D9E8200432050 /* TabSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelection.swift; sourceTree = "<group>"; };
+		DD1D52932E1DA31000432050 /* TabCustomizationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCustomizationSettingsView.swift; sourceTree = "<group>"; };
 		DD2C2E4E2D3B8AEC006413A5 /* NightscoutSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutSettingsView.swift; sourceTree = "<group>"; };
 		DD2C2E502D3B8B0B006413A5 /* NightscoutSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutSettingsViewModel.swift; sourceTree = "<group>"; };
 		DD2C2E532D3C37D7006413A5 /* DexcomSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexcomSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -863,6 +867,7 @@
 		DD1A97122D429495000DDC11 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DD1D52932E1DA31000432050 /* TabCustomizationSettingsView.swift */,
 				DD83164F2DE4E635004467AA /* SettingsMenuView.swift */,
 				DD2C2E552D3C3913006413A5 /* DexcomSettingsView.swift */,
 				DD2C2E532D3C37D7006413A5 /* DexcomSettingsViewModel.swift */,
@@ -1456,6 +1461,7 @@
 		FCC688542489367300A0279D /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				DD1D52912E1D9E8200432050 /* TabSelection.swift */,
 				DD83164B2DE4DB3A004467AA /* BinaryFloatingPoint+localized.swift */,
 				DD4AFB3A2DB55CB600BB593F /* TimeOfDay.swift */,
 				DD7B0D432D730A320063DCB6 /* CycleHelper.swift */,
@@ -1825,6 +1831,7 @@
 				DD0B9D582DE1F3B20090C337 /* AlarmType+canAcknowledge.swift in Sources */,
 				DD2C2E562D3C3917006413A5 /* DexcomSettingsView.swift in Sources */,
 				DD7F4BC52DD3CE0700D449E9 /* AlarmBGLimitSection.swift in Sources */,
+				DD1D52942E1DA31000432050 /* TabCustomizationSettingsView.swift in Sources */,
 				DD7F4B9F2DD1F92700D449E9 /* AlarmActiveSection.swift in Sources */,
 				DD4AFB672DB68C5500BB593F /* UUID+Identifiable.swift in Sources */,
 				DD9ED0CA2D355257000D2A63 /* LogView.swift in Sources */,
@@ -2019,6 +2026,7 @@
 				DD4878032C7B297E0048F05C /* StorageValue.swift in Sources */,
 				DD4878192C7C56D60048F05C /* TrioNightscoutRemoteController.swift in Sources */,
 				FC1BDD2B24A22650001B652C /* Stats.swift in Sources */,
+				DD1D52922E1D9E8200432050 /* TabSelection.swift in Sources */,
 				DDA9ACAC2D6B317100E6F1A9 /* ContactType.swift in Sources */,
 				DDDF6F432D479A9900884336 /* LoopNightscoutRemoteView.swift in Sources */,
 				DDD10F052C529DA200D76A8E /* ObservableValue.swift in Sources */,

--- a/LoopFollow/Application/Base.lproj/Main.storyboard
+++ b/LoopFollow/Application/Base.lproj/Main.storyboard
@@ -337,7 +337,7 @@
         <!--Nightscout-->
         <scene sceneID="wg7-f3-ORb">
             <objects>
-                <viewController id="8rJ-Kc-sve" customClass="NightscoutViewController" customModule="LoopFollow" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NightscoutViewController" id="8rJ-Kc-sve" customClass="NightscoutViewController" customModule="LoopFollow" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QS5-Rx-YEW">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/LoopFollow/Helpers/TabSelection.swift
+++ b/LoopFollow/Helpers/TabSelection.swift
@@ -1,0 +1,33 @@
+// LoopFollow
+// TabSelection.swift
+// Created by Jonas Björkert.
+
+enum TabSelection: String, CaseIterable, Codable {
+    case alarms
+    case remote
+    case nightscout
+
+    var displayName: String {
+        switch self {
+        case .alarms: return "Alarms"
+        case .remote: return "Remote"
+        case .nightscout: return "Nightscout"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .alarms: return "alarm"
+        case .remote: return "antenna.radiowaves.left.and.right"
+        case .nightscout: return "safari"
+        }
+    }
+
+    var storyboardIdentifier: String {
+        switch self {
+        case .alarms: return "AlarmViewController"
+        case .remote: return "RemoteViewController"
+        case .nightscout: return "NightscoutViewController"
+        }
+    }
+}

--- a/LoopFollow/Settings/SettingsMenuView.swift
+++ b/LoopFollow/Settings/SettingsMenuView.swift
@@ -44,6 +44,12 @@ struct SettingsMenuView: View {
                         settingsPath.value.append(Sheet.graph)
                     }
 
+                    NavigationRow(title: "Tab Customization",
+                                  icon: "rectangle.3.group")
+                    {
+                        settingsPath.value.append(Sheet.tabCustomization)
+                    }
+
                     if !nightscoutURL.value.isEmpty {
                         NavigationRow(title: "Information Display Settings",
                                       icon: "info.circle")
@@ -226,6 +232,7 @@ private enum Sheet: Hashable, Identifiable {
     case calendar, contact
     case advanced
     case viewLog
+    case tabCustomization
 
     var id: Self { self }
 
@@ -245,6 +252,7 @@ private enum Sheet: Hashable, Identifiable {
         case .contact: ContactSettingsView(viewModel: .init())
         case .advanced: AdvancedSettingsView(viewModel: .init())
         case .viewLog: LogView(viewModel: .init())
+        case .tabCustomization: TabCustomizationSettingsView()
         }
     }
 }

--- a/LoopFollow/Settings/TabCustomizationSettingsView.swift
+++ b/LoopFollow/Settings/TabCustomizationSettingsView.swift
@@ -1,0 +1,35 @@
+// LoopFollow
+// TabCustomizationSettingsView.swift
+// Created by Jonas Björkert.
+
+import SwiftUI
+
+struct TabCustomizationSettingsView: View {
+    @ObservedObject var tab2Selection = Storage.shared.tab2Selection
+    @ObservedObject var tab4Selection = Storage.shared.tab4Selection
+
+    var body: some View {
+        Form {
+            Section("Tab Customization") {
+                Picker("Tab 2", selection: $tab2Selection.value) {
+                    ForEach(TabSelection.allCases, id: \.self) { selection in
+                        Text(selection.displayName).tag(selection)
+                    }
+                }
+
+                Picker("Tab 4", selection: $tab4Selection.value) {
+                    ForEach(TabSelection.allCases, id: \.self) { selection in
+                        Text(selection.displayName).tag(selection)
+                    }
+                }
+            }
+
+            Section {
+                Text("Note: Home (Tab 1), Snoozer (Tab 3), and Settings (Tab 5) cannot be changed")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .navigationBarTitle("Tab Settings", displayMode: .inline)
+    }
+}

--- a/LoopFollow/Storage/Storage+Migrate.swift
+++ b/LoopFollow/Storage/Storage+Migrate.swift
@@ -375,6 +375,19 @@ extension Storage {
         migrateRecBolusAlarm()
     }
 
+    func migrateStep2() {
+        // Migrate from remoteType-based tab selection to user-configurable tabs
+        if remoteType.value == .none {
+            // If remote is disabled, set tab 2 to Alarms
+            tab2Selection.value = .alarms
+        } else {
+            // If remote is enabled (any type), set tab 2 to Remote
+            tab2Selection.value = .remote
+        }
+
+        // Tab 4 defaults to nightscout (already set by default value)
+    }
+
     // MARK: - One-off alarm migrations
 
     /// Reads *all* `alertUrgentLow*` keys, converts them into a single `Alarm`,

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -162,6 +162,9 @@ class Storage {
 
     var lastLoopingChecked = StorageValue<Date?>(key: "lastLoopingChecked", defaultValue: nil)
 
+    var tab2Selection = StorageValue<TabSelection>(key: "tab2Selection", defaultValue: .alarms)
+    var tab4Selection = StorageValue<TabSelection>(key: "tab4Selection", defaultValue: .nightscout)
+
     static let shared = Storage()
     private init() {}
 }


### PR DESCRIPTION
## Description

This PR implements user-configurable tab customization, allowing users to select what appears in tabs 2 and 4 of the tab bar. Previously, tab 2 was dynamically set based on whether remote was enabled, but now users have full control over their tab arrangement.

## Changes

- Added `TabSelection` enum to centralize tab configuration (display name, SF symbol, storyboard identifier)
- Added storage values for `tab2Selection` and `tab4Selection` with defaults (Alarms and Nightscout respectively)
- Created `TabCustomizationSettingsView` for users to configure their tab preferences
- Added migration step 2 to preserve existing user preferences (Remote users get Remote in tab 2, others get Alarms)
- Updated `MainViewController` to use the new dynamic tab system
- Fixed Nightscout tab enable/disable logic to work regardless of tab position
- Added missing storyboard identifier for NightscoutViewController

## User Experience

Users can now go to Settings → App Settings → Tab Customization to choose what appears in tabs 2 and 4 from:
- Alarms
- Remote  
- Nightscout

The fixed tabs remain:
- Tab 1: Home (fixed)
- Tab 3: Snoozer (fixed)
- Tab 5: Settings (fixed)

## Migration

Existing users will have their preferences preserved:
- If Remote was enabled: Tab 2 = Remote
- If Remote was disabled: Tab 2 = Alarms
- Tab 4 defaults to Nightscout for all users

## Testing

- [x] Verified tab customization works correctly
- [x] Tested migration preserves existing user preferences
- [x] Confirmed Nightscout tab is properly disabled when URL is empty
- [x] Verified all tab combinations work as expected

Closes #333