### PR TITLE
Avoid starting an action at xx:00; when GitHub resources can be impacted

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -7,8 +7,9 @@ on:
   #push:
 
   schedule:
-    - cron: "0 12 * * 3" # Checks for updates at 12:00 UTC every Wednesday
-    - cron: "0 10 1 * *" # Builds the app on the 1st of every month at 10:00 UTC
+    # avoid starting an action at xx:00 when GitHub resources are impacted
+    - cron: "17 12 * * 3" # Checks for updates at 12:17 UTC every Wednesday
+    - cron: "17 10 1 * *" # Builds the app on the 1st of every month at 10:17 UTC
 
 env:  
   UPSTREAM_REPO: loopandlearn/LoopFollow
@@ -197,7 +198,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '0 10 1 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '17 10 1 * *') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:


### PR DESCRIPTION
## Problem being addressed

There are now being many reports of builds failing on the automatic build days because of no resources available at GitHub.

## Problem solution

Modify the minute at which the automatic builds happen - avoid the top of the hour.
Choose a different minute for build in the open-source AID community.

###

For LoopFollow, change from xx:00 to xx:17