### PR TITLE
Ensure overrides are visible when predictions are disabled

### DIFF
--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -21,7 +21,10 @@ extension MainViewController {
         }
 
         let now = Date().timeIntervalSince1970
-        let maxEndDate = now + Storage.shared.predictionToLoad.value * 3600
+        let minimumFutureDisplayHours = 1.0
+        let effectiveFutureHours = max(Storage.shared.predictionToLoad.value, minimumFutureDisplayHours)
+        let maxEndDate = now + effectiveFutureHours * 3600
+
         let graphHorizon = dateTimeUtils.getTimeIntervalNHoursAgo(N: 24 * Storage.shared.downloadDays.value)
 
         for i in 0 ..< sorted.count {


### PR DESCRIPTION
Closes #435

This PR resolves an issue where setting the prediction time to 0 would cause overrides to be calculated with an end date equal to the current time. This made them look like they are ended on the graph and impossible to cancel with a remote command, as they didn't appear to be active.

The fix introduces a minimum display duration for overrides. The code now calculates the `maxEndDate` by using the greater of the user's `predictionToLoad` setting or a new `minimumFutureDisplayHours` constant (defaulting to 1 hour).

This ensures that a long override is always rendered for at least one hour into the future, making it visible and actionable even when prediction lines are turned off.