### PR TITLE
Fixes #154: Enable zoom in Nightscout view

### DIFF
--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -23,7 +23,10 @@ class NightscoutViewController: UIViewController {
 
         guard let myUrl = URL(string: url) else { return }
 
-        webView.configuration.preferences.javaScriptEnabled = true
+        let webpagePreferences = WKWebpagePreferences()
+        webpagePreferences.allowsContentJavaScript = true
+        webView.configuration.defaultWebpagePreferences = webpagePreferences
+
         webView.navigationDelegate = self
         webView.uiDelegate = self
         webView.load(URLRequest(url: myUrl))
@@ -31,8 +34,6 @@ class NightscoutViewController: UIViewController {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(reloadWebView(_:)), for: .valueChanged)
         webView.scrollView.addSubview(refreshControl)
-
-        webView.uiDelegate = self
     }
 
     @objc func reloadWebView(_ sender: UIRefreshControl) {
@@ -41,7 +42,6 @@ class NightscoutViewController: UIViewController {
         sender.endRefreshing()
     }
 
-    // New code to clear web cache
     func clearWebCache() {
         let dataStore = WKWebsiteDataStore.default()
         let cacheTypes = Set([WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache])
@@ -105,5 +105,16 @@ extension NightscoutViewController: WKNavigationDelegate, WKUIDelegate {
         }
 
         return nil
+    }
+
+    func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+        let javascript = """
+        var meta = document.querySelector('meta[name="viewport"]');
+        if (meta) {
+            meta.setAttribute('content', 'width=device-width, initial-scale=0.9, maximum-scale=5.0, user-scalable=yes');
+        }
+        """
+
+        webView.evaluateJavaScript(javascript)
     }
 }


### PR DESCRIPTION
Closes #154.

## Description

This PR introduces two improvements to the `NightscoutViewController`:

* **Enables Pinch-to-Zoom:** The Nightscout page disables user scaling via its viewport `<meta>` tag. This change injects a small JavaScript snippet after the page loads to override this setting (`user-scalable=0`), allowing users to pinch-to-zoom on the graph as requested in the issue.

* **Fixes Deprecation Warning:** Updates the code to resolve a warning for `javaScriptEnabled`, which was deprecated in iOS 14. It now uses the modern `WKWebpagePreferences` API to enable JavaScript, improving code health and future compatibility.

## How to Test

1.  Navigate to the Nightscout view in the app.
2.  Verify that you can now pinch-to-zoom on the web content.
3.  Confirm the project builds without warnings related to `javaScriptEnabled`.