### PR TITLE
Enlarge BG text and add optional display name

### DIFF
--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -29,12 +29,12 @@ struct SnoozerView: View {
                     if isLandscape {
                         HStack(spacing: 0) {
                             leftColumn(isLandscape: true)
-                            rightColumn
+                            rightColumn(isLandscape: true)
                         }
                     } else {
                         VStack(spacing: 0) {
                             leftColumn(isLandscape: false)
-                            rightColumn
+                            rightColumn(isLandscape: false)
                         }
                     }
                 }
@@ -47,6 +47,12 @@ struct SnoozerView: View {
 
     private func leftColumn(isLandscape: Bool) -> some View {
         VStack(spacing: 0) {
+            if !isLandscape && showDisplayName.value {
+                Text(Bundle.main.displayName)
+                    .font(.system(size: 50, weight: .bold))
+                    .foregroundColor(.white.opacity(0.9))
+            }
+
             Text(bgText.value)
                 .font(.system(size: 300, weight: .black))
                 .minimumScaleFactor(0.5)
@@ -96,14 +102,14 @@ struct SnoozerView: View {
 
     // MARK: - Right Column (Clock/Alert + Snooze Controls)
 
-    private var rightColumn: some View {
+    private func rightColumn(isLandscape: Bool) -> some View {
         VStack(spacing: 0) {
             Spacer()
-            if showDisplayName.value {
+            if showDisplayName.value && isLandscape {
                 Text(Bundle.main.displayName)
-                    .font(.title2.weight(.semibold))
-                    .foregroundColor(.white.opacity(0.8))
-                    .padding(.bottom, 4)
+                    .font(.system(size: 50, weight: .bold))
+                    .foregroundColor(.white.opacity(0.9))
+                    .padding(.bottom, 8)
             }
 
             if let alarm = vm.activeAlarm {

--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct SnoozerView: View {
     @StateObject private var vm = SnoozerViewModel()
 
+    @ObservedObject var showDisplayName = Storage.shared.showDisplayName
     @ObservedObject var minAgoText = Observable.shared.minAgoText
     @ObservedObject var bgText = Observable.shared.bgText
     @ObservedObject var bgTextColor = Observable.shared.bgTextColor
@@ -22,17 +23,17 @@ struct SnoozerView: View {
                 Color.black
                     .edgesIgnoringSafeArea(.all)
 
+                let isLandscape = geo.size.width > geo.size.height
+
                 Group {
-                    if geo.size.width > geo.size.height {
-                        // Landscape: two columns
+                    if isLandscape {
                         HStack(spacing: 0) {
-                            leftColumn
+                            leftColumn(isLandscape: true)
                             rightColumn
                         }
                     } else {
-                        // Portrait: single column
                         VStack(spacing: 0) {
-                            leftColumn
+                            leftColumn(isLandscape: false)
                             rightColumn
                         }
                     }
@@ -44,10 +45,10 @@ struct SnoozerView: View {
 
     // MARK: - Left Column (BG / Direction / Delta / Age)
 
-    private var leftColumn: some View {
+    private func leftColumn(isLandscape: Bool) -> some View {
         VStack(spacing: 0) {
             Text(bgText.value)
-                .font(.system(size: 220, weight: .black))
+                .font(.system(size: 250, weight: .black))
                 .minimumScaleFactor(0.5)
                 .foregroundColor(bgTextColor.value)
                 .strikethrough(
@@ -55,19 +56,33 @@ struct SnoozerView: View {
                     pattern: .solid,
                     color: bgStale.value ? .red : .clear
                 )
-                .frame(maxWidth: .infinity, maxHeight: 167)
+                .frame(maxWidth: .infinity, maxHeight: 200)
 
-            Text(directionText.value)
-                .font(.system(size: 110, weight: .black))
+            if isLandscape {
+                HStack(alignment: .firstTextBaseline, spacing: 20) {
+                    Text(directionText.value)
+                        .font(.system(size: 90, weight: .black))
+
+                    Text(deltaText.value)
+                        .font(.system(size: 70))
+                }
                 .minimumScaleFactor(0.5)
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, maxHeight: 96)
 
-            Text(deltaText.value)
-                .font(.system(size: 70))
-                .minimumScaleFactor(0.5)
-                .foregroundColor(.white.opacity(0.8))
-                .frame(maxWidth: .infinity, maxHeight: 78)
+            } else {
+                Text(directionText.value)
+                    .font(.system(size: 110, weight: .black))
+                    .minimumScaleFactor(0.5)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, maxHeight: 96)
+
+                Text(deltaText.value)
+                    .font(.system(size: 70))
+                    .minimumScaleFactor(0.5)
+                    .foregroundColor(.white.opacity(0.8))
+                    .frame(maxWidth: .infinity, maxHeight: 78)
+            }
 
             Text(minAgoText.value)
                 .font(.system(size: 70))
@@ -84,6 +99,12 @@ struct SnoozerView: View {
     private var rightColumn: some View {
         VStack(spacing: 0) {
             Spacer()
+            if showDisplayName.value {
+                Text(Bundle.main.displayName)
+                    .font(.title2.weight(.semibold))
+                    .foregroundColor(.white.opacity(0.8))
+                    .padding(.bottom, 4)
+            }
 
             if let alarm = vm.activeAlarm {
                 VStack(spacing: 16) {

--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -48,7 +48,7 @@ struct SnoozerView: View {
     private func leftColumn(isLandscape: Bool) -> some View {
         VStack(spacing: 0) {
             Text(bgText.value)
-                .font(.system(size: 250, weight: .black))
+                .font(.system(size: 300, weight: .black))
                 .minimumScaleFactor(0.5)
                 .foregroundColor(bgTextColor.value)
                 .strikethrough(
@@ -56,7 +56,7 @@ struct SnoozerView: View {
                     pattern: .solid,
                     color: bgStale.value ? .red : .clear
                 )
-                .frame(maxWidth: .infinity, maxHeight: 200)
+                .frame(maxWidth: .infinity, maxHeight: 240)
 
             if isLandscape {
                 HStack(alignment: .firstTextBaseline, spacing: 20) {
@@ -68,27 +68,27 @@ struct SnoozerView: View {
                 }
                 .minimumScaleFactor(0.5)
                 .foregroundColor(.white)
-                .frame(maxWidth: .infinity, maxHeight: 96)
+                .frame(maxWidth: .infinity, maxHeight: 80)
 
             } else {
                 Text(directionText.value)
                     .font(.system(size: 110, weight: .black))
                     .minimumScaleFactor(0.5)
                     .foregroundColor(.white)
-                    .frame(maxWidth: .infinity, maxHeight: 96)
+                    .frame(maxWidth: .infinity, maxHeight: 80)
 
                 Text(deltaText.value)
                     .font(.system(size: 70))
                     .minimumScaleFactor(0.5)
                     .foregroundColor(.white.opacity(0.8))
-                    .frame(maxWidth: .infinity, maxHeight: 78)
+                    .frame(maxWidth: .infinity, maxHeight: 68)
             }
 
             Text(minAgoText.value)
-                .font(.system(size: 70))
+                .font(.system(size: 60))
                 .minimumScaleFactor(0.5)
                 .foregroundColor(.white.opacity(0.6))
-                .frame(maxWidth: .infinity, maxHeight: 48)
+                .frame(maxWidth: .infinity, maxHeight: 40)
         }
         .padding(.top, 16)
         .padding(.horizontal, 16)


### PR DESCRIPTION
This PR introduces several enhancements to the Snoozer view to improve at-a-glance readability and provide better user context, addressing Issue #440 .

**Key Changes:**

* **Larger BG Text:** The font size and frame for the BG value have been increased, making it the primary focal point of the view.
* **Optional Display Name:** The app's display name can now be shown in the `rightColumn`, which works well in both portrait and landscape modes. This is controlled by the `showDisplayName` setting.
* **Adaptive Landscape Layout:** In landscape mode, the trend arrow and delta value are now displayed side-by-side for a more compact and readable layout.
