### PR TITLE
Larger and more visible Snooze Button

### DIFF
--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -47,7 +47,7 @@ struct SnoozerView: View {
     private var leftColumn: some View {
         VStack(spacing: 0) {
             Text(bgText.value)
-                .font(.system(size: 220, weight: .black))
+                .font(.system(size: 350, weight: .black))
                 .minimumScaleFactor(0.5)
                 .foregroundColor(bgTextColor.value)
                 .strikethrough(

--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -116,9 +116,9 @@ struct SnoozerView: View {
                     Button(action: vm.snoozeTapped) {
                         Text(vm.snoozeUnits == 0 ? "Acknowledge" : "Snooze")
                             .font(.title2).bold()
-                            .frame(maxWidth: .infinity, minHeight: 50)
-                            .background(Color.accentColor)
-                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity, minHeight: 100)
+                            .background(Color.white)
+                            .foregroundColor(.black)
                             .cornerRadius(12)
                     }
                     .padding(.horizontal, 24)


### PR DESCRIPTION
In case this is of interest to the broader community, in addition to increasing the size of the BG in the Snoozer screen (which is being addressed in a different pull request), I also increased the size of the snooze button and adjusted the color to stand out at night.  Fully recognize that a large white button could be considered overly bright for others but I find it helpful for when I do not have my glasses on in the dark.

Team - feel free to reject and/or alter any of this.  Simply sharing in case it's helpful.