### PR TITLE
feat: Enhance snooze button visibility with larger size and orange color

### DIFF
--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -142,11 +142,11 @@ struct SnoozerView: View {
 
                     Button(action: vm.snoozeTapped) {
                         Text(vm.snoozeUnits == 0 ? "Acknowledge" : "Snooze")
-                            .font(.title2).bold()
-                            .frame(maxWidth: .infinity, minHeight: 50)
-                            .background(Color.accentColor)
+                            .font(.system(size: 30, weight: .bold))
+                            .frame(maxWidth: .infinity, minHeight: 80)
+                            .background(Color.orange)
                             .foregroundColor(.white)
-                            .cornerRadius(12)
+                            .clipShape(Capsule())
                     }
                     .padding(.horizontal, 24)
                     .padding(.bottom, 20)

--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -143,7 +143,7 @@ struct SnoozerView: View {
                     Button(action: vm.snoozeTapped) {
                         Text(vm.snoozeUnits == 0 ? "Acknowledge" : "Snooze")
                             .font(.system(size: 30, weight: .bold))
-                            .frame(maxWidth: .infinity, minHeight: 80)
+                            .frame(maxWidth: .infinity, minHeight: 60)
                             .background(Color.orange)
                             .foregroundColor(.white)
                             .clipShape(Capsule())


### PR DESCRIPTION
## Description

Improves the visibility and usability of the snooze button in SnoozerView for better accessibility, especially for users without glasses in dark conditions.

## Changes

- Increased button height from 50pt to 80pt for easier tapping
- Changed button color from accent color (blue) to orange for better visibility
- Increased font size to 30pt for improved readability
- Changed button shape from rounded rectangle to capsule for modern Apple design aesthetic
- Maintained white text color for optimal contrast

## Motivation

The snooze button needs to be highly visible and easy to tap during nighttime alarm scenarios. The orange color provides better contrast against the black background while maintaining Apple's design language for time-sensitive actions.

## Screenshots
![793D37AD-27CC-416B-9DF6-5104CB2F6C5F_4_5005_c](https://github.com/user-attachments/assets/81b73429-2160-4e76-a62f-e6929d282ebd)
![E81D992C-BCCB-451E-8079-CE7D93EB2F77_4_5005_c](https://github.com/user-attachments/assets/3bb0e53f-30cf-4f0f-8df0-1c27cbfc9276)

