### PR TITLE
Only run swiftformat in the LoopFollow folder [skip ci]

### DIFF
--- a/Scripts/swiftformat.sh
+++ b/Scripts/swiftformat.sh
@@ -1,5 +1,12 @@
 #! /bin/sh
 
+# Check if the folder name is exactly "LoopFollow"
+FOLDER_NAME=$(basename "${SRCROOT}")
+if [ "${FOLDER_NAME}" != "LoopFollow" ]; then
+    echo "Skipping swiftformat: This script only runs in the LoopFollow directory, not in '${FOLDER_NAME}'"
+    exit 0
+fi
+
 function assertEnvironment {
 	if [ -z $1 ]; then 
 		echo $2


### PR DESCRIPTION
### Problem
The swiftformat script was running on `LoopFollow_second`, `LoopFollow_third`, replacing original author headers. This caused incorrect attribution since git sees the person who copied the files as the "author" in these repos.

### Solution
Modified the swiftformat build script to only run on the main `LoopFollow` repository by checking that the folder name is exactly "LoopFollow".

### Changes
- Added folder name validation before running swiftformat
- Script exits gracefully (exit 0) when run in non-LoopFollow directories
- Shows informative skip message for clarity

### Impact
- Original author headers preserved in derivative repos
- No change to main LoopFollow repo behavior
- Build processes remain unaffected

### Testing
- [x] Verified script runs normally in `LoopFollow` directory
- [x] Confirmed script skips execution in `LoopFollow_second` directory
- [x] Builds complete successfully in both scenarios