### PR TITLE
Add global snooze to snooze page

### DIFF
--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -156,22 +156,90 @@ struct SnoozerView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
                 .animation(.spring(), value: vm.activeAlarm != nil)
             } else {
-                TimelineView(.periodic(from: .now, by: 1)) { context in
-                    VStack(spacing: 4) {
-                        if snoozerEmoji.value {
-                            Text(bgEmoji)
-                                .font(.system(size: 128))
-                                .minimumScaleFactor(0.5)
-                        }
+                VStack {
+                    Spacer()
 
-                        Text(context.date, format: Date.FormatStyle(date: .omitted, time: .shortened))
-                            .font(.system(size: 70))
-                            .minimumScaleFactor(0.5)
-                            .foregroundColor(.white)
-                            .frame(height: 78)
+                    // Global snooze indicator (positioned above clock)
+                    if vm.isGlobalSnoozeActive {
+                        HStack {
+                            Image(systemName: "moon.fill")
+                                .foregroundColor(.orange)
+                            Text("All Alarms Snoozed")
+                                .font(.headline)
+                                .foregroundColor(.orange)
+                        }
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 8)
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(12)
+                        .padding(.bottom, 16)
                     }
+
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        VStack(spacing: 4) {
+                            if snoozerEmoji.value {
+                                Text(bgEmoji)
+                                    .font(.system(size: 128))
+                                    .minimumScaleFactor(0.5)
+                            }
+
+                            HStack {
+                                Text(context.date, format: Date.FormatStyle(date: .omitted, time: .shortened))
+                                    .font(.system(size: 70))
+                                    .minimumScaleFactor(0.5)
+                                    .foregroundColor(.white)
+
+                                if vm.isGlobalSnoozeActive {
+                                    Image(systemName: "moon.fill")
+                                        .font(.system(size: 24))
+                                        .foregroundColor(.orange)
+                                }
+                            }
+                            .frame(height: 78)
+                        }
+                    }
+
+                    Spacer()
+
+                    // Global snooze controls (anchored to bottom)
+                    VStack(spacing: 24) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Snooze all alarms for")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                HStack {
+                                    Text("\(vm.globalSnoozeUnits) minutes")
+                                        .font(.title3).bold()
+                                        .foregroundColor(.white)
+                                    Spacer()
+                                    Stepper("", value: $vm.globalSnoozeUnits,
+                                            in: 15 ... 480, // 15 minutes to 8 hours
+                                            step: 15)
+                                        .labelsHidden()
+                                        .onChange(of: vm.globalSnoozeUnits) { _ in
+                                            vm.globalSnoozeDurationChanged()
+                                        }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 24)
+                        .padding(.top, 12)
+
+                        Button(action: vm.toggleGlobalSnooze) {
+                            Text(vm.isGlobalSnoozeActive ? "Disable Global Snooze" : "Snooze All Alarms")
+                                .font(.title3).bold()
+                                .frame(maxWidth: .infinity, minHeight: 60)
+                                .background(vm.isGlobalSnoozeActive ? Color.red : Color.accentColor)
+                                .foregroundColor(.white)
+                                .clipShape(Capsule())
+                        }
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 20)
+                    }
+                    .background(.ultraThinMaterial)
+                    .cornerRadius(20, corners: [.topLeft, .topRight])
                 }
-                Spacer()
             }
         }
     }

--- a/LoopFollow/Snoozer/SnoozerViewModel.swift
+++ b/LoopFollow/Snoozer/SnoozerViewModel.swift
@@ -10,6 +10,10 @@ final class SnoozerViewModel: ObservableObject {
     @Published var snoozeUnits: Int = 5
     @Published var timeUnitLabel: String = "minutes"
 
+    // Global snooze properties
+    @Published var globalSnoozeUnits: Int = 60 // Default to 1 hour
+    @Published var isGlobalSnoozeActive: Bool = false
+
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -30,9 +34,62 @@ final class SnoozerViewModel: ObservableObject {
         if let alarm = activeAlarm {
             snoozeUnits = alarm.snoozeDuration
         }
+
+        // Observe alarm configuration changes
+        Storage.shared.alarmConfiguration.$value
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateGlobalSnoozeState()
+            }
+            .store(in: &cancellables)
+
+        // Initialize global snooze state
+        updateGlobalSnoozeState()
     }
 
     func snoozeTapped() {
         AlarmManager.shared.performSnooze(snoozeUnits)
+    }
+
+    // MARK: - Global Snooze Methods
+
+    func updateGlobalSnoozeState() {
+        let config = Storage.shared.alarmConfiguration.value
+        isGlobalSnoozeActive = config.snoozeUntil?.compare(Date()) == .orderedDescending
+    }
+
+    func toggleGlobalSnooze() {
+        var config = Storage.shared.alarmConfiguration.value
+
+        if isGlobalSnoozeActive {
+            // Turn off global snooze
+            config.snoozeUntil = nil
+        } else {
+            // Turn on global snooze
+            config.snoozeUntil = Date().addingTimeInterval(TimeInterval(globalSnoozeUnits * 60))
+        }
+
+        Storage.shared.alarmConfiguration.value = config
+        updateGlobalSnoozeState()
+
+        // Stop any current alarm when global snooze is activated
+        if isGlobalSnoozeActive {
+            AlarmManager.shared.stopAlarm()
+        }
+    }
+
+    func setGlobalSnoozeDuration(_ minutes: Int) {
+        globalSnoozeUnits = minutes
+
+        // If global snooze is currently active, update the duration
+        if isGlobalSnoozeActive {
+            var config = Storage.shared.alarmConfiguration.value
+            config.snoozeUntil = Date().addingTimeInterval(TimeInterval(minutes * 60))
+            Storage.shared.alarmConfiguration.value = config
+        }
+    }
+
+    func globalSnoozeDurationChanged() {
+        setGlobalSnoozeDuration(globalSnoozeUnits)
     }
 }


### PR DESCRIPTION
## Overview
This PR introduces enhancements to the LoopFollow app's alarm management system: global snooze functionality 

## Features Added

### 1. Global Snooze System
- **Global Snooze Control**: Users can now snooze all alarms at once from the snooze page
- **Duration Configuration**: Adjustable snooze duration from 15 minutes to 8 hours (15-minute increments)
- **Visual Indicators**: 
  - Moon icon appears when global snooze is active
  - Clear status display in the clock interface
  - Toggle button with color-coded states (accent color for enable, red for disable)

## Technical Implementation

### Global Snooze
- **Files Modified**: `SnoozerView.swift`, `SnoozerViewModel.swift`
- **Key Components**:
  - `globalSnoozeUnits` property for duration control
  - `isGlobalSnoozeActive` for state management
  - Integration with existing `AlarmManager` system
  - Real-time UI updates based on alarm configuration changes

### Default Behavior
- Global snooze defaults to 60 minutes duration