### PR TITLE
Fix(alarm): Correct logic for missed reading alert

### DIFF
--- a/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
@@ -9,7 +9,7 @@ struct MissedReadingCondition: AlarmCondition {
     static let type: AlarmType = .missedReading
     init() {}
 
-    func evaluate(alarm: Alarm, data: AlarmData, now _: Date) -> Bool {
+    func evaluate(alarm: Alarm, data: AlarmData, now : Date) -> Bool {
         // ────────────────────────────────
         // 0. sanity checks
         // ────────────────────────────────
@@ -18,7 +18,7 @@ struct MissedReadingCondition: AlarmCondition {
         // Skip if we have *no* readings
         guard let last = data.bgReadings.last else { return false }
 
-        let secondsSinceLast = Date().timeIntervalSince(last.date)
+        let secondsSinceLast = now.timeIntervalSince(last.date)
         return secondsSinceLast >= thresholdMinutes * 60
     }
 }

--- a/LoopFollow/Alarm/AlarmManager.swift
+++ b/LoopFollow/Alarm/AlarmManager.swift
@@ -70,8 +70,10 @@ class AlarmManager {
                 continue
             }
 
-            // If the alarm is based on bg values, and the value isnt recent, skip to next
-            if alarm.type.isBGBased, !isLatestReadingRecent {
+            // If an alarm is BG-based, it usually requires recent data.
+            // We make a specific exception for .missedReading, whose entire
+            // purpose is to fire when recent BG data is NOT recent.
+            if alarm.type.isBGBased, alarm.type != .missedReading, !isLatestReadingRecent {
                 continue
             }
 


### PR DESCRIPTION
This PR fixes a bug where the Missed Reading alert would not trigger when CGM data became stale.

### Problem

The alert was being blocked by a global check that required all `isBGBased` alarms to have *recent* BG data. This directly conflicted with the purpose of the Missed Reading alert.

### Solution

-   The alarm remains classified as `isBGBased` to correctly use the system's debounce logic (`lastBGAlarmTime`).
-   A targeted exception, `alarm.type != .missedReading`, is added to the "recent data" check, allowing the alarm to fire as intended.
-   The condition logic is also updated to use the correct `now` timestamp for consistency.