### PR TITLE
Remove 'Created by' line from SwiftFormat header

### DIFF
--- a/LoopFollow/Alarm/AddAlarm/AddAlarmSheet.swift
+++ b/LoopFollow/Alarm/AddAlarm/AddAlarmSheet.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AddAlarmSheet.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AddAlarm/AlarmTile.swift
+++ b/LoopFollow/Alarm/AddAlarm/AlarmTile.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmTile.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/Alarm+byPriorityThenSpec.swift
+++ b/LoopFollow/Alarm/Alarm+byPriorityThenSpec.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Alarm+byPriorityThenSpec.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/Alarm.swift
+++ b/LoopFollow/Alarm/Alarm.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Alarm.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Alarm/AlarmCondition/AlarmCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/AlarmCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/BatteryCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/BatteryCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BatteryCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/BatteryDropCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/BatteryDropCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BatteryDropCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/BuildExpireCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/BuildExpireCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BuildExpireCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/COBCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/COBCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // COBCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/FastDropCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/FastDropCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // FastDropCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/FastRiseCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/FastRiseCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // FastRiseCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/HighBGCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/HighBGCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // HighBGCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/IOBCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/IOBCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // IOBCondition.swift
-// Created by Jonas Björkert.
 
 //
 //  IOBCondition.swift

--- a/LoopFollow/Alarm/AlarmCondition/LowBGCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/LowBGCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LowBGCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/MissedBolusCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/MissedBolusCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MissedBolusCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MissedReadingCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/NotLoopingCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/NotLoopingCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NotLoopingCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/OverrideEndCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/OverrideEndCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverrideEndCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/OverrideStartCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/OverrideStartCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverrideStartCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/PumpChangeCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/PumpChangeCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PumpChangeCondition.swift
-// Created by Jonas Björkert.
 
 //
 //  PumpChangeCondition.swift

--- a/LoopFollow/Alarm/AlarmCondition/PumpVolumeCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/PumpVolumeCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PumpVolumeCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/RecBolusCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/RecBolusCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RecBolusCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/SensorAgeCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/SensorAgeCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SensorAgeCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/TempTargetEndCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/TempTargetEndCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetEndCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/TempTargetStartCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/TempTargetStartCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetStartCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmCondition/TemporaryCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/TemporaryCondition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TemporaryCondition.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmConfiguration.swift
+++ b/LoopFollow/Alarm/AlarmConfiguration.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmConfiguration.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmData.swift
+++ b/LoopFollow/Alarm/AlarmData.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmData.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmEditing/AlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/AlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmActiveSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmActiveSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmActiveSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmAudioSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmAudioSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmAudioSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmBGLimitSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmBGLimitSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmBGLimitSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmBGSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmBGSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmBGSection.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmGeneralSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmGeneralSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmGeneralSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmSnoozeSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmSnoozeSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmSnoozeSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/AlarmStepperSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/AlarmStepperSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmStepperSection.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/DeleteAlarmSection.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/DeleteAlarmSection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DeleteAlarmSection.swift
-// Created by Jonas Björkert.
 
 //
 //  DeleteAlarmSection.swift

--- a/LoopFollow/Alarm/AlarmEditing/Components/InfoBanner.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/InfoBanner.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoBanner.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Components/SoundFile.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Components/SoundFile.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SoundFile.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/BatteryAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/BatteryAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BatteryAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/BatteryDropAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/BatteryDropAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BatteryDropAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/BuildExpireAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/BuildExpireAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BuildExpireAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/COBAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/COBAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // COBAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/FastDropAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/FastDropAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // FastDropAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/FastRiseAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/FastRiseAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // FastRiseAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/HighBgAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/HighBgAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // HighBgAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/IOBAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/IOBAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // IOBAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/LowBgAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/LowBgAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LowBgAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/MissedBolusAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/MissedBolusAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MissedBolusAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/MissedReadingEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/MissedReadingEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MissedReadingEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/NotLoopingAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/NotLoopingAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NotLoopingAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/OverrideEndAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/OverrideEndAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverrideEndAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/OverrideStartAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/OverrideStartAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverrideStartAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/PumpChangeAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/PumpChangeAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PumpChangeAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/PumpVolumeAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/PumpVolumeAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PumpVolumeAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/RecBolusAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/RecBolusAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RecBolusAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/SensorAgeAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/SensorAgeAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SensorAgeAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/TempTargetEndAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/TempTargetEndAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetEndAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/TempTargetStartAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/TempTargetStartAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetStartAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmEditing/Editors/TemporaryAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/TemporaryAlarmEditor.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TemporaryAlarmEditor.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmListView.swift
+++ b/LoopFollow/Alarm/AlarmListView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmListView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmManager.swift
+++ b/LoopFollow/Alarm/AlarmManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UserNotifications

--- a/LoopFollow/Alarm/AlarmSettingsView.swift
+++ b/LoopFollow/Alarm/AlarmSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/AlarmType/AlarmType+Snooze.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+Snooze.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmType+Snooze.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmType/AlarmType+SortDirection.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+SortDirection.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmType+SortDirection.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmType/AlarmType+canAcknowledge.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+canAcknowledge.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmType+canAcknowledge.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmType/AlarmType+timeUnit.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+timeUnit.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmType+timeUnit.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmType/AlarmType.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmType.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/AlarmsContainerView.swift
+++ b/LoopFollow/Alarm/AlarmsContainerView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmsContainerView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Alarm/DataStructs/BolusEntry.swift
+++ b/LoopFollow/Alarm/DataStructs/BolusEntry.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BolusEntry.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/DataStructs/CarbSample.swift
+++ b/LoopFollow/Alarm/DataStructs/CarbSample.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CarbSample.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/DataStructs/GlucoseValue.swift
+++ b/LoopFollow/Alarm/DataStructs/GlucoseValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // GlucoseValue.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Alarm/SnoozeState.swift
+++ b/LoopFollow/Alarm/SnoozeState.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SnoozeState.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Application/AppDelegate.swift
+++ b/LoopFollow/Application/AppDelegate.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AppDelegate.swift
-// Created by Jon Fawcett.
 
 import CoreData
 import EventKit

--- a/LoopFollow/Application/SceneDelegate.swift
+++ b/LoopFollow/Application/SceneDelegate.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SceneDelegate.swift
-// Created by Jon Fawcett.
 
 import AVFoundation
 import UIKit

--- a/LoopFollow/BackgroundRefresh/BT/BLEDevice.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BLEDevice.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BLEDevice.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/BackgroundRefresh/BT/BLEDeviceSelectionView.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BLEDeviceSelectionView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BLEDeviceSelectionView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/BackgroundRefresh/BT/BLEManager.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BLEManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BLEManager.swift
-// Created by Jonas Björkert.
 
 import Combine
 import CoreBluetooth

--- a/LoopFollow/BackgroundRefresh/BT/BluetoothDevice.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BluetoothDevice.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BluetoothDevice.swift
-// Created by Jonas Björkert.
 
 import CoreBluetooth
 import Foundation

--- a/LoopFollow/BackgroundRefresh/BT/BluetoothDeviceDelegate.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BluetoothDeviceDelegate.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BluetoothDeviceDelegate.swift
-// Created by Jonas Björkert.
 
 import CoreBluetooth
 import Foundation

--- a/LoopFollow/BackgroundRefresh/BT/Devices/DexcomHeartbeatBluetoothDevice.swift
+++ b/LoopFollow/BackgroundRefresh/BT/Devices/DexcomHeartbeatBluetoothDevice.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DexcomHeartbeatBluetoothDevice.swift
-// Created by Jonas Björkert.
 
 import AVFoundation
 import CoreBluetooth

--- a/LoopFollow/BackgroundRefresh/BT/Devices/OmnipodDashHeartbeatBluetoothTransmitter.swift
+++ b/LoopFollow/BackgroundRefresh/BT/Devices/OmnipodDashHeartbeatBluetoothTransmitter.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OmnipodDashHeartbeatBluetoothTransmitter.swift
-// Created by Jonas Björkert.
 
 import CoreBluetooth
 import Foundation

--- a/LoopFollow/BackgroundRefresh/BT/Devices/RileyLinkHeartbeatBluetoothDevice.swift
+++ b/LoopFollow/BackgroundRefresh/BT/Devices/RileyLinkHeartbeatBluetoothDevice.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RileyLinkHeartbeatBluetoothDevice.swift
-// Created by Jonas Björkert.
 
 import CoreBluetooth
 import Foundation

--- a/LoopFollow/BackgroundRefresh/BT/DexcomG7HeartBeat.swift
+++ b/LoopFollow/BackgroundRefresh/BT/DexcomG7HeartBeat.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DexcomG7HeartBeat.swift
-// Created by Jonas Björkert.
 
 // Denna behövs
 

--- a/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsView.swift
+++ b/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BackgroundRefreshSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsViewModel.swift
+++ b/LoopFollow/BackgroundRefresh/BackgroundRefreshSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BackgroundRefreshSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/BackgroundRefresh/BackgroundRefreshType.swift
+++ b/LoopFollow/BackgroundRefresh/BackgroundRefreshType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BackgroundRefreshType.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Contact/ContactColorOption.swift
+++ b/LoopFollow/Contact/ContactColorOption.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactColorOption.swift
-// Created by Jonas Björkert.
 
 import UIKit
 

--- a/LoopFollow/Contact/ContactImageUpdater.swift
+++ b/LoopFollow/Contact/ContactImageUpdater.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactImageUpdater.swift
-// Created by Jonas Björkert.
 
 import Contacts
 import Foundation

--- a/LoopFollow/Contact/ContactIncludeOption.swift
+++ b/LoopFollow/Contact/ContactIncludeOption.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactIncludeOption.swift
-// Created by Jonas Björkert.
 
 enum ContactIncludeOption: String, Codable, Equatable, CaseIterable {
     case off = "Off"

--- a/LoopFollow/Contact/ContactType.swift
+++ b/LoopFollow/Contact/ContactType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactType.swift
-// Created by Jonas Björkert.
 
 enum ContactType: String, CaseIterable {
     case BG

--- a/LoopFollow/Controllers/AlarmSound.swift
+++ b/LoopFollow/Controllers/AlarmSound.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmSound.swift
-// Created by Jon Fawcett.
 
 import AVFoundation
 import Foundation

--- a/LoopFollow/Controllers/BackgroundAlertManager.swift
+++ b/LoopFollow/Controllers/BackgroundAlertManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BackgroundAlertManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UserNotifications

--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Graphs.swift
-// Created by Jon Fawcett.
 
 import Charts
 import Foundation

--- a/LoopFollow/Controllers/MainViewController+updateStats.swift
+++ b/LoopFollow/Controllers/MainViewController+updateStats.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MainViewController+updateStats.swift
-// Created by Jon Fawcett.
 
 import Charts
 import Foundation

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NightScout.swift
-// Created by Jon Fawcett.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BGData.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Controllers/Nightscout/CAge.swift
+++ b/LoopFollow/Controllers/Nightscout/CAge.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CAge.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DeviceStatus.swift
-// Created by Jonas Björkert.
 
 import Charts
 import Foundation

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DeviceStatusLoop.swift
-// Created by Jonas Björkert.
 
 import Charts
 import Foundation

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DeviceStatusOpenAPS.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Controllers/Nightscout/IAge.swift
+++ b/LoopFollow/Controllers/Nightscout/IAge.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // IAge.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/NSProfile.swift
+++ b/LoopFollow/Controllers/Nightscout/NSProfile.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NSProfile.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Profile.swift
+++ b/LoopFollow/Controllers/Nightscout/Profile.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Profile.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/ProfileManager.swift
+++ b/LoopFollow/Controllers/Nightscout/ProfileManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ProfileManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Controllers/Nightscout/SAge.swift
+++ b/LoopFollow/Controllers/Nightscout/SAge.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SAge.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Treatments.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BGCheck.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Controllers/Nightscout/Treatments/Basals.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Basals.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Basals.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/Bolus.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Bolus.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Bolus.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/Carbs.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Carbs.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Carbs.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/InsulinCartridgeChange.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/InsulinCartridgeChange.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InsulinCartridgeChange.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/Notes.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Notes.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Notes.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Overrides.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Controllers/Nightscout/Treatments/ResumePump.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/ResumePump.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ResumePump.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/SMB.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/SMB.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SMB.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/SensorStart.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/SensorStart.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SensorStart.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/SiteChange.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/SiteChange.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SiteChange.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/SuspendPump.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/SuspendPump.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SuspendPump.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Nightscout/Treatments/TemporaryTarget.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/TemporaryTarget.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TemporaryTarget.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Controllers/SpeakBG.swift
+++ b/LoopFollow/Controllers/SpeakBG.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SpeakBG.swift
-// Created by Jonas Björkert.
 
 import AVFoundation
 import CallKit

--- a/LoopFollow/Controllers/Stats.swift
+++ b/LoopFollow/Controllers/Stats.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Stats.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Timers.swift
-// Created by Jon Fawcett.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Extensions/Binding+Optional.swift
+++ b/LoopFollow/Extensions/Binding+Optional.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Binding+Optional.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import SwiftUI

--- a/LoopFollow/Extensions/EKEventStore+Extensions.swift
+++ b/LoopFollow/Extensions/EKEventStore+Extensions.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // EKEventStore+Extensions.swift
-// Created by Jonas Björkert.
 
 import EventKit
 import Foundation

--- a/LoopFollow/Extensions/HKQuantity+AnyConvertible.swift
+++ b/LoopFollow/Extensions/HKQuantity+AnyConvertible.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // HKQuantity+AnyConvertible.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 

--- a/LoopFollow/Extensions/HKUnit+Extensions.swift
+++ b/LoopFollow/Extensions/HKUnit+Extensions.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // HKUnit+Extensions.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Extensions/ShareClientExtension.swift
+++ b/LoopFollow/Extensions/ShareClientExtension.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ShareClientExtension.swift
-// Created by Jose Paredes.
 
 import Foundation
 import ShareClient

--- a/LoopFollow/Extensions/UIViewExtension.swift
+++ b/LoopFollow/Extensions/UIViewExtension.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // UIViewExtension.swift
-// Created by Jose Paredes.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Extensions/UUID+Identifiable.swift
+++ b/LoopFollow/Extensions/UUID+Identifiable.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // UUID+Identifiable.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/AnyConvertible.swift
+++ b/LoopFollow/Helpers/AnyConvertible.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AnyConvertible.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/AppConstants.swift
+++ b/LoopFollow/Helpers/AppConstants.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AppConstants.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/AppVersionManager.swift
+++ b/LoopFollow/Helpers/AppVersionManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AppVersionManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/BackgroundTaskAudio.swift
+++ b/LoopFollow/Helpers/BackgroundTaskAudio.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BackgroundTaskAudio.swift
-// Created by Jon Fawcett.
 
 import AVFoundation
 

--- a/LoopFollow/Helpers/BinaryFloatingPoint+localized.swift
+++ b/LoopFollow/Helpers/BinaryFloatingPoint+localized.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BinaryFloatingPoint+localized.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/BuildDetails.swift
+++ b/LoopFollow/Helpers/BuildDetails.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BuildDetails.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/Chart.swift
+++ b/LoopFollow/Helpers/Chart.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Chart.swift
-// Created by Jon Fawcett.
 
 import Charts
 import Foundation

--- a/LoopFollow/Helpers/CycleHelper.swift
+++ b/LoopFollow/Helpers/CycleHelper.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CycleHelper.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/DataStructs.swift
+++ b/LoopFollow/Helpers/DataStructs.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DataStructs.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/DateExtensions.swift
+++ b/LoopFollow/Helpers/DateExtensions.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DateExtensions.swift
-// Created by codebymini.
 
 import Foundation
 

--- a/LoopFollow/Helpers/DateTime.swift
+++ b/LoopFollow/Helpers/DateTime.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DateTime.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/DictionaryKeyPath.swift
+++ b/LoopFollow/Helpers/DictionaryKeyPath.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DictionaryKeyPath.swift
-// Created by Jon Fawcett.
 
 // For details, see
 // http://stackoverflow.com/questions/40261857/remove-nested-key-from-dictionary

--- a/LoopFollow/Helpers/GitHubService.swift
+++ b/LoopFollow/Helpers/GitHubService.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // GitHubService.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/Globals.swift
+++ b/LoopFollow/Helpers/Globals.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Globals.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/GlucoseConversion.swift
+++ b/LoopFollow/Helpers/GlucoseConversion.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // GlucoseConversion.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/JWTManager.swift
+++ b/LoopFollow/Helpers/JWTManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // JWTManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import SwiftJWT

--- a/LoopFollow/Helpers/Localizer.swift
+++ b/LoopFollow/Helpers/Localizer.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Localizer.swift
-// Created by Jon Fawcett.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Helpers/Mobileprovision.swift
+++ b/LoopFollow/Helpers/Mobileprovision.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Mobileprovision.swift
-// Created by Jon Fawcett.
 
 //
 //  MobileProvision.swift

--- a/LoopFollow/Helpers/NightscoutUtils.swift
+++ b/LoopFollow/Helpers/NightscoutUtils.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NightscoutUtils.swift
-// Created by bjorkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/ObservationToken.swift
+++ b/LoopFollow/Helpers/ObservationToken.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ObservationToken.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/TOTPGenerator.swift
+++ b/LoopFollow/Helpers/TOTPGenerator.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TOTPGenerator.swift
-// Created by codebymini.
 
 import CommonCrypto
 import Foundation

--- a/LoopFollow/Helpers/TabPosition.swift
+++ b/LoopFollow/Helpers/TabPosition.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TabPosition.swift
-// Created by Jonas Björkert.
 
 enum TabPosition: String, CaseIterable, Codable {
     case position2

--- a/LoopFollow/Helpers/TextFieldWithToolBar.swift
+++ b/LoopFollow/Helpers/TextFieldWithToolBar.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TextFieldWithToolBar.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Helpers/TimeOfDay.swift
+++ b/LoopFollow/Helpers/TimeOfDay.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TimeOfDay.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Helpers/Views/ActionRow.swift
+++ b/LoopFollow/Helpers/Views/ActionRow.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ActionRow.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/Views/BGPicker.swift
+++ b/LoopFollow/Helpers/Views/BGPicker.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BGPicker.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Helpers/Views/ErrorMessageView.swift
+++ b/LoopFollow/Helpers/Views/ErrorMessageView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ErrorMessageView.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import SwiftUI

--- a/LoopFollow/Helpers/Views/Glyph.swift
+++ b/LoopFollow/Helpers/Views/Glyph.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Glyph.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/Views/HKQuantityInputView.swift
+++ b/LoopFollow/Helpers/Views/HKQuantityInputView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // HKQuantityInputView.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Helpers/Views/LinkRow.swift
+++ b/LoopFollow/Helpers/Views/LinkRow.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LinkRow.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import SwiftUI

--- a/LoopFollow/Helpers/Views/LoadingButtonView.swift
+++ b/LoopFollow/Helpers/Views/LoadingButtonView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LoadingButtonView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/Views/NavigationRow.swift
+++ b/LoopFollow/Helpers/Views/NavigationRow.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NavigationRow.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/Views/SettingsStepperRow.swift
+++ b/LoopFollow/Helpers/Views/SettingsStepperRow.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SettingsStepperRow.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/Views/SimpleQRCodeScannerView.swift
+++ b/LoopFollow/Helpers/Views/SimpleQRCodeScannerView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SimpleQRCodeScannerView.swift
-// Created by codebymini.
 
 import AVFoundation
 import SwiftUI

--- a/LoopFollow/Helpers/Views/TogglableSecureInput.swift
+++ b/LoopFollow/Helpers/Views/TogglableSecureInput.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TogglableSecureInput.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Helpers/carbBolusArrays.swift
+++ b/LoopFollow/Helpers/carbBolusArrays.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // carbBolusArrays.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Helpers/isOnPhoneCall.swift
+++ b/LoopFollow/Helpers/isOnPhoneCall.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // isOnPhoneCall.swift
-// Created by Jonas Björkert.
 
 import CallKit
 import Foundation

--- a/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsView.swift
+++ b/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoDisplaySettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsViewModel.swift
+++ b/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoDisplaySettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import SwiftUI

--- a/LoopFollow/InfoTable/InfoData.swift
+++ b/LoopFollow/InfoTable/InfoData.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoData.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/InfoTable/InfoDataSeparator.swift
+++ b/LoopFollow/InfoTable/InfoDataSeparator.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoDataSeparator.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/InfoTable/InfoManager.swift
+++ b/LoopFollow/InfoTable/InfoManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/InfoTable/InfoType.swift
+++ b/LoopFollow/InfoTable/InfoType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InfoType.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Log/LogEntry.swift
+++ b/LoopFollow/Log/LogEntry.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LogEntry.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Log/LogManager.swift
+++ b/LoopFollow/Log/LogManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LogManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Log/LogView.swift
+++ b/LoopFollow/Log/LogView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LogView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Log/LogViewModel.swift
+++ b/LoopFollow/Log/LogViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LogViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Log/SearchBar.swift
+++ b/LoopFollow/Log/SearchBar.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SearchBar.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 import UIKit

--- a/LoopFollow/Metric/CarbMetric.swift
+++ b/LoopFollow/Metric/CarbMetric.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CarbMetric.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Metric/InsulinMetric.swift
+++ b/LoopFollow/Metric/InsulinMetric.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // InsulinMetric.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Metric/Metric.swift
+++ b/LoopFollow/Metric/Metric.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Metric.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Nightscout/NightscoutSettingsView.swift
+++ b/LoopFollow/Nightscout/NightscoutSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NightscoutSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
+++ b/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NightscoutSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LoopAPNSBolusView.swift
-// Created by codebymini.
 
 import HealthKit
 import LocalAuthentication

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSCarbsView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSCarbsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LoopAPNSCarbsView.swift
-// Created by codebymini.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSRemoteView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSRemoteView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LoopAPNSRemoteView.swift
-// Created by codebymini.
 
 import SwiftUI
 

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSService.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSService.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // LoopAPNSService.swift
-// Created by codebymini.
 
 import CryptoKit
 import Foundation

--- a/LoopFollow/Remote/LoopAPNS/OverridePresetData.swift
+++ b/LoopFollow/Remote/LoopAPNS/OverridePresetData.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverridePresetData.swift
-// Created by codebymini.
 
 import Foundation
 

--- a/LoopFollow/Remote/LoopAPNS/OverridePresetsView.swift
+++ b/LoopFollow/Remote/LoopAPNS/OverridePresetsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverridePresetsView.swift
-// Created by codebymini.
 
 import SwiftUI
 

--- a/LoopFollow/Remote/Nightscout/TrioNightscoutRemoteView.swift
+++ b/LoopFollow/Remote/Nightscout/TrioNightscoutRemoteView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TrioNightscoutRemoteView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Remote/NoRemoteView.swift
+++ b/LoopFollow/Remote/NoRemoteView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NoRemoteView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Remote/RemoteType.swift
+++ b/LoopFollow/Remote/RemoteType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RemoteType.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Remote/RemoteViewController.swift
+++ b/LoopFollow/Remote/RemoteViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RemoteViewController.swift
-// Created by Jonas Björkert.
 
 import Combine
 import SwiftUI

--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RemoteSettingsView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Remote/Settings/RemoteSettingsViewModel.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // RemoteSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Remote/TRC/BolusView.swift
+++ b/LoopFollow/Remote/TRC/BolusView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BolusView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import LocalAuthentication

--- a/LoopFollow/Remote/TRC/MealView.swift
+++ b/LoopFollow/Remote/TRC/MealView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MealView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import LocalAuthentication

--- a/LoopFollow/Remote/TRC/OverrideView.swift
+++ b/LoopFollow/Remote/TRC/OverrideView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // OverrideView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Remote/TRC/PushMessage.swift
+++ b/LoopFollow/Remote/TRC/PushMessage.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PushMessage.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Remote/TRC/PushNotificationManager.swift
+++ b/LoopFollow/Remote/TRC/PushNotificationManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // PushNotificationManager.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Remote/TRC/TRCCommandType.swift
+++ b/LoopFollow/Remote/TRC/TRCCommandType.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TRCCommandType.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Remote/TRC/TempTargetView.swift
+++ b/LoopFollow/Remote/TRC/TempTargetView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetView.swift
-// Created by Jonas Björkert.
 
 import HealthKit
 import SwiftUI

--- a/LoopFollow/Remote/TRC/TreatmentResponse.swift
+++ b/LoopFollow/Remote/TRC/TreatmentResponse.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TreatmentResponse.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Remote/TRC/TrioNightscoutRemoteController.swift
+++ b/LoopFollow/Remote/TRC/TrioNightscoutRemoteController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TrioNightscoutRemoteController.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Remote/TRC/TrioRemoteControlView.swift
+++ b/LoopFollow/Remote/TRC/TrioRemoteControlView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TrioRemoteControlView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Remote/TRC/TrioRemoteControlViewModel.swift
+++ b/LoopFollow/Remote/TRC/TrioRemoteControlViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TrioRemoteControlViewModel.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Remote/TempTargetPreset/TempTargetPreset.swift
+++ b/LoopFollow/Remote/TempTargetPreset/TempTargetPreset.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetPreset.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Remote/TempTargetPreset/TempTargetPresetManager.swift
+++ b/LoopFollow/Remote/TempTargetPreset/TempTargetPresetManager.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TempTargetPresetManager.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Settings/AdvancedSettingsView.swift
+++ b/LoopFollow/Settings/AdvancedSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AdvancedSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Settings/AdvancedSettingsViewModel.swift
+++ b/LoopFollow/Settings/AdvancedSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AdvancedSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Settings/CalendarSettingsView.swift
+++ b/LoopFollow/Settings/CalendarSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CalendarSettingsView.swift
-// Created by Jonas Björkert.
 
 import EventKit
 import SwiftUI

--- a/LoopFollow/Settings/ContactSettingsView.swift
+++ b/LoopFollow/Settings/ContactSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactSettingsView.swift
-// Created by Jonas Björkert.
 
 import Contacts
 import SwiftUI

--- a/LoopFollow/Settings/ContactSettingsViewModel.swift
+++ b/LoopFollow/Settings/ContactSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ContactSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Settings/DexcomSettingsView.swift
+++ b/LoopFollow/Settings/DexcomSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DexcomSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Settings/DexcomSettingsViewModel.swift
+++ b/LoopFollow/Settings/DexcomSettingsViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DexcomSettingsViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Settings/GeneralSettingsView.swift
+++ b/LoopFollow/Settings/GeneralSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // GeneralSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Settings/GraphSettingsView.swift
+++ b/LoopFollow/Settings/GraphSettingsView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // GraphSettingsView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Settings/SettingsMenuView.swift
+++ b/LoopFollow/Settings/SettingsMenuView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SettingsMenuView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 import UIKit

--- a/LoopFollow/Settings/TabCustomizationModal.swift
+++ b/LoopFollow/Settings/TabCustomizationModal.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TabCustomizationModal.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Snoozer/SnoozerView.swift
+++ b/LoopFollow/Snoozer/SnoozerView.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SnoozerView.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 

--- a/LoopFollow/Snoozer/SnoozerViewController.swift
+++ b/LoopFollow/Snoozer/SnoozerViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SnoozerViewController.swift
-// Created by Jonas Björkert.
 
 import Combine
 import SwiftUI

--- a/LoopFollow/Snoozer/SnoozerViewModel.swift
+++ b/LoopFollow/Snoozer/SnoozerViewModel.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SnoozerViewModel.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Framework/ObservableUserDefaultsValue.swift
+++ b/LoopFollow/Storage/Framework/ObservableUserDefaultsValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ObservableUserDefaultsValue.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Framework/ObservableValue.swift
+++ b/LoopFollow/Storage/Framework/ObservableValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ObservableValue.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Framework/SecureStorageValue.swift
+++ b/LoopFollow/Storage/Framework/SecureStorageValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SecureStorageValue.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Framework/StorageValue.swift
+++ b/LoopFollow/Storage/Framework/StorageValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // StorageValue.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Framework/UserDefaultsValue.swift
+++ b/LoopFollow/Storage/Framework/UserDefaultsValue.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // UserDefaultsValue.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Storage/Framework/UserDefaultsValueGroups.swift
+++ b/LoopFollow/Storage/Framework/UserDefaultsValueGroups.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // UserDefaultsValueGroups.swift
-// Created by Jon Fawcett.
 
 import Foundation
 

--- a/LoopFollow/Storage/Observable.swift
+++ b/LoopFollow/Storage/Observable.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Observable.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Storage/ObservableUserDefaults.swift
+++ b/LoopFollow/Storage/ObservableUserDefaults.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ObservableUserDefaults.swift
-// Created by Jonas Björkert.
 
 import Combine
 import Foundation

--- a/LoopFollow/Storage/Storage+Migrate.swift
+++ b/LoopFollow/Storage/Storage+Migrate.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Storage+Migrate.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Storage.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import HealthKit

--- a/LoopFollow/Task/AlarmTask.swift
+++ b/LoopFollow/Task/AlarmTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/BGTask.swift
+++ b/LoopFollow/Task/BGTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BGTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/CalendarTask.swift
+++ b/LoopFollow/Task/CalendarTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // CalendarTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/DeviceStatusTask.swift
+++ b/LoopFollow/Task/DeviceStatusTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // DeviceStatusTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/MinAgoTask.swift
+++ b/LoopFollow/Task/MinAgoTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MinAgoTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Task/ProfileTask.swift
+++ b/LoopFollow/Task/ProfileTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // ProfileTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/Task.swift
+++ b/LoopFollow/Task/Task.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Task.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TaskScheduler.swift
-// Created by Jonas Björkert.
 
 import Foundation
 import UIKit

--- a/LoopFollow/Task/TreatmentsTask.swift
+++ b/LoopFollow/Task/TreatmentsTask.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TreatmentsTask.swift
-// Created by Jonas Björkert.
 
 import Foundation
 

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AlarmViewController.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 import UIKit

--- a/LoopFollow/ViewControllers/AppStateViewController.swift
+++ b/LoopFollow/ViewControllers/AppStateViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // AppStateViewController.swift
-// Created by Jose Paredes.
 
 import Foundation
 

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MainViewController.swift
-// Created by Jon Fawcett.
 
 import AVFAudio
 import Charts

--- a/LoopFollow/ViewControllers/MoreMenuViewController.swift
+++ b/LoopFollow/ViewControllers/MoreMenuViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // MoreMenuViewController.swift
-// Created by Jonas Björkert.
 
 import SwiftUI
 import UIKit

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // NightScoutViewController.swift
-// Created by Jon Fawcett.
 
 import UIKit
 import WebKit

--- a/LoopFollow/ViewControllers/SettingsViewController.swift
+++ b/LoopFollow/ViewControllers/SettingsViewController.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // SettingsViewController.swift
-// Created by Jon Fawcett.
 
 import SwiftUI
 import UIKit

--- a/Scripts/swiftformat.sh
+++ b/Scripts/swiftformat.sh
@@ -19,5 +19,5 @@ assertEnvironment "${SRCROOT}" "Please set SRCROOT to project root folder"
 unset SDKROOT
 
 swift run -c release --package-path BuildTools swiftformat "${SRCROOT}" \
---header "LoopFollow\n{file}\nCreated by {author.name}." \
+--header "LoopFollow\n{file}" \
 --exclude Pods,Generated,R.generated.swift,fastlane/swift,Dependencies,dexcom-share-client-swift

--- a/Tests/AlarmConditions/BatteryConditionTests.swift
+++ b/Tests/AlarmConditions/BatteryConditionTests.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // BatteryConditionTests.swift
-// Created by Jonas Björkert.
 
 @testable import LoopFollow
 import Testing

--- a/Tests/AlarmConditions/Helpers.swift
+++ b/Tests/AlarmConditions/Helpers.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Helpers.swift
-// Created by Jonas Björkert.
 
 // Tests/AlarmConditions/Helpers.swift
 import Foundation

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // Tests.swift
-// Created by Jonas Björkert.
 
 import Testing
 


### PR DESCRIPTION
## Description

This pull request removes the `// Created by {author}` line from the file headers generated by our SwiftFormat script.

The `swiftformat` tool sources the author's name from the Git history. This has proven to be a source of instability and code churn for our project. Operations such as squashing commits during a merge can change the perceived author of a file in Git's history.

This leads to the `// Created by...` line fluctuating between different developers during routine builds, creating unnecessary diffs and noise in commits.

By removing this dynamic line from the header template, we ensure that file headers remain consistent and predictable across all development and CI environments. This change helps to reduce noise in our commit history and code reviews.

### Changes Made

- Updated the SwiftFormat execution script to modify the `--header` parameter.
  - **Before:** `--header "LoopFollow\n{file}\nCreated by {author}."`
  - **After:** `--header "LoopFollow\n{file}"`
- Ran SwiftFormat across the entire project to apply the new, cleaner header to all relevant files.