### PR TITLE
Update to Xcode 16.4

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -203,7 +203,7 @@ jobs:
       )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |


### PR DESCRIPTION
The Browser Build for LoopFollow began to fail about 14 August 2025, after previously succeeding.

By modifying the explicit version request from Xcode_16.2 to Xcode_16.4, the builds began working again.

At this time, we tested several options and determined the best approach is to explicitly specify the highest minor version that works correctly.

| Explicit Request | Result |
|:--|:-:|
| Xcode 16.2 | fail |
| Xcode 16.3 | succeed |
| Xcode 16.4 | succeed |
| Xcode 16 | fail |