### PR TITLE
chore: clean up linting change [skip ci]

### DIFF
--- a/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
@@ -8,7 +8,7 @@ struct MissedReadingCondition: AlarmCondition {
     static let type: AlarmType = .missedReading
     init() {}
 
-    func evaluate(alarm: Alarm, data: AlarmData, now : Date) -> Bool {
+    func evaluate(alarm: Alarm, data: AlarmData, now: Date) -> Bool {
         // ────────────────────────────────
         // 0. sanity checks
         // ────────────────────────────────

--- a/LoopFollow/Remote/LoopAPNS/TOTPService.swift
+++ b/LoopFollow/Remote/LoopAPNS/TOTPService.swift
@@ -1,6 +1,5 @@
 // LoopFollow
 // TOTPService.swift
-// Created by codebymini.
 
 import Foundation
 


### PR DESCRIPTION
Some files are automatically modified when building using Xcode.
Clean these up but don't bump version because there is no change to code function.