### PR TITLE
Add passcode fallback for Loop APNS insulin

### DIFF
--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
@@ -326,13 +326,28 @@ struct LoopAPNSBolusView: View {
                     if success {
                         sendInsulinConfirmed()
                     } else {
-                        alertMessage = "Authentication failed"
-                        alertType = .error
-                        showAlert = true
+                        // Biometric authentication failed, try passcode fallback
+                        self.authenticateWithPasscode()
                     }
                 }
             }
         } else if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            // No biometrics available, go directly to passcode
+            authenticateWithPasscode()
+        } else {
+            alertMessage = "Authentication not available"
+            alertType = .error
+            showAlert = true
+        }
+    }
+
+    private func authenticateWithPasscode() {
+        let context = LAContext()
+        var error: NSError?
+
+        let reason = "Confirm your identity to send insulin."
+
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
                 DispatchQueue.main.async {
                     if success {
@@ -345,7 +360,7 @@ struct LoopAPNSBolusView: View {
                 }
             }
         } else {
-            alertMessage = "Biometric authentication not available"
+            alertMessage = "Authentication not available"
             alertType = .error
             showAlert = true
         }


### PR DESCRIPTION
# PR Summary: Add Passcode Fallback for Biometric Authentication
## Changes Made
* Enhanced authentication flow in LoopAPNSBolusView.swift to automatically fallback to passcode when biometric authentication fails
* Added new authenticateWithPasscode() method to handle passcode authentication separately
* Improved user experience by eliminating unnecessary error prompts when biometric auth fails
## Technical Details
* Modified authenticateAndSendInsulin() to call authenticateWithPasscode() when biometric authentication fails instead of showing an error
* When biometrics are unavailable, the flow now goes directly to passcode authentication
* Error messages are now only shown when both biometric and passcode authentication fail
* Removed unused biometricError parameter for cleaner code
## User Impact
* Users will no longer see "Authentication failed" errors when biometric authentication fails
* Seamless transition from biometric to passcode authentication
* Only shows error when all authentication methods fail
* Maintains security while improving usability