### PR TITLE
Shift GitHub to check for updates every Sunday and build 2nd Saturday of each month

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -9,7 +9,7 @@ on:
   schedule:
     # avoid starting an action at times when GitHub resources are impacted
     - cron: "17 12 * * 0" # Checks for updates at 12:17 UTC every Sunday
-    - cron: "17 10 9 * *" # Builds the app on the 9th of every month at 10:17 UTC
+    - cron: "17 10 8-14 * 6" # Builds the app on the second Saturday of each month 10:17 UTC
 
 env:  
   UPSTREAM_REPO: loopandlearn/LoopFollow
@@ -198,7 +198,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '17 10 9 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '17 10 8-14 * 6') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:

--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -7,9 +7,9 @@ on:
   #push:
 
   schedule:
-    # avoid starting an action at xx:00 when GitHub resources are impacted
-    - cron: "17 12 * * 3" # Checks for updates at 12:17 UTC every Wednesday
-    - cron: "17 10 1 * *" # Builds the app on the 1st of every month at 10:17 UTC
+    # avoid starting an action at times when GitHub resources are impacted
+    - cron: "17 12 * * 0" # Checks for updates at 12:17 UTC every Sunday
+    - cron: "17 10 9 * *" # Builds the app on the 9th of every month at 10:17 UTC
 
 env:  
   UPSTREAM_REPO: loopandlearn/LoopFollow
@@ -198,7 +198,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '17 10 1 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '17 10 9 * *') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:


### PR DESCRIPTION
## Purpose

Try to avoid times when GitHub actions are historically busy.
Thanks Carol Vachon for this report:

> The most significant and consistent historic pattern impacting GitHub activity is the week-to-weekend cycle, as most development work happens during the standard workweek.

> * Lowest activity: Weekends, especially Sundays, see the least amount of activity, as most developers are off work.
> * Highest activity: Activity is typically at its peak from Tuesday to Thursday.
> * Moderate activity: Mondays and Fridays have moderate activity as developers ease into and out of the workweek.

On Wed, Oct 1, GitHub actions were impacted and all builds across the Open Source community all failed.

## Method

* Shift the weekly build in case of code updates from Wednesday to Sunday
* Shift the monthly builds, regardless of whether code was updated, from the 1st of the month to the second Saturday of each month