### PR TITLE
Remove usage of insulinReqMetric

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -116,14 +116,6 @@ extension MainViewController {
                 }
             }
 
-            // Insulin Required
-            if let insulinReqMetric = InsulinMetric(from: enactedOrSuggested, key: "insulinReq") {
-                infoManager.updateInfoData(type: .recBolus, value: insulinReqMetric)
-                Observable.shared.deviceRecBolus.value = insulinReqMetric.value
-            } else {
-                Observable.shared.deviceRecBolus.value = 0
-            }
-
             // Autosens
             if let sens = enactedOrSuggested["sensitivityRatio"] as? Double {
                 let formattedSens = String(format: "%.0f", sens * 100.0) + "%"


### PR DESCRIPTION
Removed usage of `insulinReq` from Nightscout `devicestatus`, as it is **not suitable** for displaying as a recommended bolus.  
This value is an internal oref field that is heavily adjusted and **not equivalent** to Trio’s bolus calculator output.  
A proper replacement will be added later when the correct bolus recommendation becomes available from Trio.