### PR TITLE
Add small delay to TOTP warning when sending carbs/insulin

### DIFF
--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSBolusView.swift
@@ -20,6 +20,7 @@ struct LoopAPNSBolusView: View {
     @State private var lastLoopTime: TimeInterval? = nil
     @State private var otpTimeRemaining: Int? = nil
     @State private var showOldCalculationWarning = false
+    @State private var showTOTPWarning = false
     private let otpPeriod: TimeInterval = 30
     private var otpTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -125,7 +126,7 @@ struct LoopAPNSBolusView: View {
                     }
 
                     // TOTP Blocking Warning Section
-                    if isTOTPBlocked {
+                    if isTOTPBlocked && showTOTPWarning {
                         Section {
                             VStack(alignment: .leading, spacing: 8) {
                                 HStack {
@@ -187,6 +188,15 @@ struct LoopAPNSBolusView: View {
 
                 // Validate TOTP state when view appears
                 _ = isTOTPBlocked
+
+                // Add delay before showing TOTP warning to prevent flash after successful send
+                if isTOTPBlocked {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        showTOTPWarning = true
+                    }
+                } else {
+                    showTOTPWarning = false
+                }
             }
             .onReceive(otpTimer) { _ in
                 let now = Date().timeIntervalSince1970

--- a/LoopFollow/Remote/LoopAPNS/LoopAPNSCarbsView.swift
+++ b/LoopFollow/Remote/LoopAPNS/LoopAPNSCarbsView.swift
@@ -16,6 +16,7 @@ struct LoopAPNSCarbsView: View {
     @State private var alertMessage = ""
     @State private var alertType: AlertType = .success
     @State private var otpTimeRemaining: Int? = nil
+    @State private var showTOTPWarning = false
     private let otpPeriod: TimeInterval = 30
     private var otpTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -178,7 +179,7 @@ struct LoopAPNSCarbsView: View {
                     }
 
                     // TOTP Blocking Warning Section
-                    if isTOTPBlocked {
+                    if isTOTPBlocked && showTOTPWarning {
                         Section {
                             VStack(alignment: .leading, spacing: 8) {
                                 HStack {
@@ -250,6 +251,15 @@ struct LoopAPNSCarbsView: View {
 
                 // Validate TOTP state when view appears
                 _ = isTOTPBlocked
+
+                // Add delay before showing TOTP warning to prevent flash after successful send
+                if isTOTPBlocked {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        showTOTPWarning = true
+                    }
+                } else {
+                    showTOTPWarning = false
+                }
             }
             .onReceive(otpTimer) { _ in
                 let now = Date().timeIntervalSince1970


### PR DESCRIPTION
Enhance TOTP warning handling in LoopAPNS views by adding a delay before displaying the warning to prevent flickering. Updated both LoopAPNSBolusView and LoopAPNSCarbsView to include a new state variable for managing the warning display.