### PR TITLE
Update the GitHub build schedule to every Sunday

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -2,10 +2,6 @@ name: 4. Build LoopFollow
 run-name: Build LoopFollow (${{ github.ref_name }})
 on:
   workflow_dispatch:
-
-  ## Remove the "#" sign from the beginning of the line below to get automated builds on push (code changes in your repository)
-  #push:
-
   schedule:
     # Check for updates every Sunday
     #   Later logic builds if there are updates or if it is the 2nd Sunday of the month
@@ -214,11 +210,8 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: write
-    # runs when started manually,
-    #   or ((SCHEDULED_BUILD missing or enabled) and (day consistent with 2nd time in the month)),
-    #   or ((SCHEDULED_SYNC missing or enabled) and (new commits were found))
     if:
-      |
+      | # builds with manual start; if automatic: once a month or when new commits are found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
         (vars.SCHEDULED_BUILD != 'false' && needs.day_in_month.outputs.IS_SECOND_IN_MONTH == 'true') ||


### PR DESCRIPTION
## Purpose

Our previous attempt to build on the second Saturday of the month was configured to build every Saturday and on the 8-14th day of the month.

While doing this PR to fix the logic, also fix the name, run-name from `Loop Follow` to `LoopFollow`. That change will be for LoopFollow only. The other apps will need similar changes to modify the build schedule.

### Update the build_xxx.yml logic. 

Change the schedule to run at a specific time every Sunday:
* modify the logic to build monthly (2nd Sunday) regardless of status
* keep the logic to build weekly if there are new commits to the code
 
This new method eliminates one build process per month. The monthly build starts at the same time as the weekly check for updates.

The once a month logic is much simpler
* add a new job `day_in_month` that determines if this is the second time this day of the week has happened in this month
* the output `IS_SECOND_IN_MONTH` is used to decide whether to skip or execute a build