### PR TITLE
Alarms: stamp 'last checked' on completion to avoid false positives

### DIFF
--- a/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/MissedReadingCondition.swift
@@ -17,6 +17,17 @@ struct MissedReadingCondition: AlarmCondition {
         // Skip if we have *no* readings
         guard let last = data.bgReadings.last else { return false }
 
+        guard let lastChecked = Storage.shared.lastBGChecked.value else {
+            // Never checked, so don't alarm.
+            return false
+        }
+
+        let checkedAgeSeconds = now.timeIntervalSince(lastChecked)
+        if checkedAgeSeconds > 360 { // 6 minutes
+            // The check itself is stale, so the data is unreliable. Don't alarm.
+            return false
+        }
+
         let secondsSinceLast = now.timeIntervalSince(last.date)
         return secondsSinceLast >= thresholdMinutes * 60
     }

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -46,6 +46,7 @@ extension MainViewController {
     func webLoadNSBGData(dexData: [ShareGlucoseData] = []) {
         // This kicks it out in the instance where dexcom fails but they aren't using NS &&
         if !IsNightscoutEnabled() {
+            Storage.shared.lastBGChecked.value = Date()
             return
         }
 
@@ -109,6 +110,8 @@ extension MainViewController {
                 // if we have Dex data, use it
                 if !dexData.isEmpty {
                     self.ProcessDexBGData(data: dexData, sourceName: "Dexcom")
+                } else {
+                    Storage.shared.lastBGChecked.value = Date()
                 }
                 return
             }
@@ -121,6 +124,7 @@ extension MainViewController {
 
         guard !data.isEmpty else {
             LogManager.shared.log(category: .nightscout, message: "No bg data received. Skipping processing.", limitIdentifier: "No bg data received. Skipping processing.")
+            Storage.shared.lastBGChecked.value = Date()
             return
         }
 
@@ -221,7 +225,10 @@ extension MainViewController {
             TaskScheduler.shared.rescheduleTask(id: .minAgoUpdate, to: Date())
 
             let entries = self.bgData
-            if entries.count < 2 { return } // Protect index out of bounds
+            if entries.count < 2 { // Protect index out of bounds
+                Storage.shared.lastBGChecked.value = Date()
+                return
+            }
 
             self.updateBGGraph()
             self.updateStats()
@@ -264,6 +271,7 @@ extension MainViewController {
                         stale: Observable.shared.bgStale.value
                     )
             }
+            Storage.shared.lastBGChecked.value = Date()
         }
     }
 }

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -7,8 +7,6 @@ import UIKit
 
 extension MainViewController {
     func webLoadNSDeviceStatus() {
-        Storage.shared.lastLoopingChecked.value = Date()
-
         let parameters = ["count": "1"]
         NightscoutUtils.executeDynamicRequest(eventType: .deviceStatus, parameters: parameters) { result in
             switch result {
@@ -16,6 +14,7 @@ extension MainViewController {
                 if let jsonDeviceStatus = json as? [[String: AnyObject]] {
                     DispatchQueue.main.async {
                         self.updateDeviceStatusDisplay(jsonDeviceStatus: jsonDeviceStatus)
+                        Storage.shared.lastLoopingChecked.value = Date()
                     }
                 } else {
                     self.handleDeviceStatusError()
@@ -29,6 +28,7 @@ extension MainViewController {
     private func handleDeviceStatusError() {
         LogManager.shared.log(category: .deviceStatus, message: "Device status fetch failed!", limitIdentifier: "Device status fetch failed!")
         DispatchQueue.main.async {
+            Storage.shared.lastLoopingChecked.value = Date()
             TaskScheduler.shared.rescheduleTask(id: .deviceStatus, to: Date().addingTimeInterval(10))
             self.evaluateNotLooping()
         }

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -160,6 +160,7 @@ class Storage {
     var persistentNotificationLastBGTime = StorageValue<Date>(key: "persistentNotificationLastBGTime", defaultValue: .distantPast)
 
     var lastLoopingChecked = StorageValue<Date?>(key: "lastLoopingChecked", defaultValue: nil)
+    var lastBGChecked = StorageValue<Date?>(key: "lastBGChecked", defaultValue: nil)
 
     var alarmsPosition = StorageValue<TabPosition>(key: "alarmsPosition", defaultValue: .position2)
     var remotePosition = StorageValue<TabPosition>(key: "remotePosition", defaultValue: .more)


### PR DESCRIPTION
## Summary
This PR fixes a race where **Missed Reading** and **Not Looping** alarms could fire while BG/Loop checks were still running.  
We now mark the “last checked” timestamps **after** the data fetch has either **succeeded (and been processed)** or **finally failed**. That way, the alarm logic only validates once the attempt is actually finished.

## What changed
- **BG**
  - Added `Storage.shared.lastBGChecked`.
  - Set on **success** at the end of `viewUpdateNSBG(...)` (after observables/UI updates).
  - Set on **final failure** when NS is disabled or NS fetch fails and there’s **no Dex fallback**; also when a processor receives **empty data**.
  - `MissedReadingCondition` now requires a recent `lastBGChecked` (≤ 6 min) before evaluating staleness.

- **Loop**
  - Moved `Storage.shared.lastLoopingChecked` from **start** of `webLoadNSDeviceStatus()` to the **end** of success handling (after `updateDeviceStatusDisplay`) and to the **error** path (final failure).
  - This mirrors the BG behavior to prevent “not looping” alarms from firing during in-flight device status checks.

## Why
Previously, we stamped the “checked” moment at the **start** of network calls. If the alarm evaluator ran in parallel—while `lastLoopTime` or BG entries were still old—we could alarm prematurely.  