### PR TITLE
RemoteSettings: exclude Loop APNS from Team ID mismatch check

### DIFF
--- a/LoopFollow/Remote/Settings/RemoteSettingsViewModel.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsViewModel.swift
@@ -63,7 +63,6 @@ class RemoteSettingsViewModel: ObservableObject {
         // Determine if a comparison is needed and perform it.
         switch remoteType {
         case .trc:
-            // For both Loop and TRC, the target Team ID is in the same storage location.
             // If the target ID is empty, there's nothing to compare.
             guard !targetTeamId.isEmpty else {
                 return false


### PR DESCRIPTION
## Summary
`areTeamIdsDifferent` should only compare Team IDs for **TRC**.  
This moves `.loopAPNS` out of the comparison path and into the “not applicable” path, preventing false “different Team IDs” states when configuring Loop APNS.