### PR TITLE
Expand and streamline build action;

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -27,7 +27,7 @@ jobs:
     # Check GH_PAT, sync repository, check day in month
     steps:
 
-      - name: Validate GH_PAT
+      - name: Access
         id: workflow-permission
         run: |
           # Validate Access Token


### PR DESCRIPTION
## Purpose

After thinking about it a bit more, there are more improvements that can be made to the GitHub actions build process than were included in PR #477.

Because there are no alive branches to consider, there is no reason to limit the sync to upstream to only work with `main` and `dev`. This way someone testing a `special` branch can run the build process and have that `special` branch pick up updates from the upstream repository.

This PR only affects the build yml file. The redesign from this PR and PR 477 can be replicated in other open source apps.

## Method

**Rules of Thumb**
* Use as few runners as possible and when possible, choose ubuntu
* Move processes later in the the process if they are not needed earlier
* Configure to skip a process if it will not be used

> For example, by moving check_certs later in the process and skipping it when build will be skipped, decreases the number of runners significantly for the weekly runs that do not trigger a build

### Details

There are 3 main jobs:
* check_status: contains all processes that can be run with ubuntu in a sequential line
* check_certs: skipped if the logic indicates a build will be skipped
* build: skipped if the logic indicates a build will be skipped

The biggest change is to check_status.
* This is now in one ubuntu runner with this order of processes

Edited this next section after updating for the following reasons (and modifying a few names):
* @bjorkert pointed out a syntax error - GitHub was smart enough to do the right thing, but corrected the error
* I tested having an incorrect GH_PAT and did not get a nice error message
   * I copied the GH_PAT checking code from validate_secrets
   * Unless you are going to build (in which case you call create_certs that calls validate_secrets), the other secrets do not need to be checked 

>    name: Check status to decide whether to build
      - name: Access
      - name: Checkout target repo
      - name: Sync upstream changes
      - name: New commits found
      - name: No new commits
      - name: Show value of 'has_new_commits'
      - name: Show scheduled build configuration message
      - name: Check if this is the second time this day-of-week happens this month
