### PR TITLE
fix validate_secrets regression, detect and annotate errors

### DIFF
--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -168,8 +168,8 @@ jobs:
           elif ! echo "$FASTLANE_KEY" | openssl pkcs8 -nocrypt >/dev/null; then
             failed=true
             echo "::error::The FASTLANE_KEY secret is set but invalid. Verify that you copied it correctly from the API Key file (*.p8) you downloaded and try again."
-          elif ! (bundle exec fastlane validate_secrets 2>&1 || true) | tee fastlane.log; then # ignore "fastlane validate_secrets" errors and continue on errors without annotating an exit code
-            if grep -q "bad decrypt" fastlane.log; then
+          elif ! bundle exec fastlane validate_secrets 2>&1 | tee fastlane.log; then
+            if grep -q "Couldn't decrypt the repo" fastlane.log; then
               failed=true
               echo "::error::Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again."
             elif grep -q -e "required agreement" -e "license agreement" fastlane.log; then


### PR DESCRIPTION
## Purpose

Fix a regression introduced when automatic certificate renewal was implemented.

This change is copied from [LoopWorkspace PR 357](https://github.com/LoopKit/LoopWorkspace/pull/357) where it was thoroughly tested.

## Method

* Remove the `|| true` statement that prevented detection of three error types when validating secrets
   * MATCH_PASSWORD was incorrect
   * the latest developer program license agreement was not signed
   * the Distribution Certificate is invalid or expired
* Update the pattern that searches for the error in the log file when the MATCH_PASSWORD value is incorrect