### PR TITLE
Updates language on alarms

### DIFF
--- a/LoopFollow/Alarm/AlarmEditing/Editors/BatteryAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/BatteryAlarmEditor.swift
@@ -17,7 +17,7 @@ struct BatteryAlarmEditor: View {
 
             AlarmStepperSection(
                 header: "Battery Level",
-                footer: "This alerts you when the battery drops below this level.",
+                footer: "This alerts you when the battery drops to or below this level.",
                 title: "Battery Below",
                 range: 0 ... 100,
                 step: 5,

--- a/LoopFollow/Alarm/AlarmEditing/Editors/COBAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/COBAlarmEditor.swift
@@ -9,7 +9,7 @@ struct COBAlarmEditor: View {
     var body: some View {
         Group {
             InfoBanner(
-                text: "Alerts when Carbs-on-Board exceeds the amount you set below.",
+                text: "Alerts when Carbs-on-Board reaches or exceeds the amount you set below.",
                 alarmType: alarm.type
             )
 
@@ -17,8 +17,8 @@ struct COBAlarmEditor: View {
 
             AlarmStepperSection(
                 header: "Carbs on Board Limit",
-                footer: "Alert when carbs-on-board is above this number.",
-                title: "Above",
+                footer: "Alert when carbs-on-board is at or above this number.",
+                title: "At or Above",
                 range: 1 ... 200,
                 step: 1,
                 unitLabel: "g",

--- a/LoopFollow/Alarm/AlarmEditing/Editors/MissedBolusAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/MissedBolusAlarmEditor.swift
@@ -41,8 +41,8 @@ struct MissedBolusAlarmEditor: View {
 
             AlarmStepperSection(
                 header: "Ignore small boluses",
-                footer: "Boluses below this size are ignored.",
-                title: "Ignore below",
+                footer: "Boluses at or below this size are ignored.",
+                title: "Ignore at or below",
                 range: 0.05 ... 2,
                 step: 0.05,
                 unitLabel: "Units",
@@ -51,8 +51,8 @@ struct MissedBolusAlarmEditor: View {
 
             AlarmStepperSection(
                 header: "Ignore small carbs",
-                footer: "Carb entries below this amount will not trigger the alarm.",
-                title: "Below",
+                footer: "Carb entries at or below this amount will not trigger the alarm.",
+                title: "At or Below",
                 range: 0 ... 15,
                 step: 1,
                 unitLabel: "Grams",

--- a/LoopFollow/Alarm/AlarmEditing/Editors/RecBolusAlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/Editors/RecBolusAlarmEditor.swift
@@ -18,8 +18,8 @@ struct RecBolusAlarmEditor: View {
 
             AlarmStepperSection(
                 header: "Threshold",
-                footer: "Alert when recommended bolus is above this value.",
-                title: "More than",
+                footer: "Alert when recommended bolus is at or above this value.",
+                title: "At or Above",
                 range: 0.1 ... 50,
                 step: 0.1,
                 unitLabel: "Units",


### PR DESCRIPTION
I've gone through the alarms language as raised in issue #507 - only text has been changed.


## Summary of Issues Found

| Alarm | Component | Previous Text | Logic | Mismatch |
|-------|-----------|---------------|-------|----------|
| **Battery** | Footer | "drops below" | `<=` | Missing "or equal to" |
| **COB** | InfoBanner | "exceeds" | `>=` | "exceeds" implies `>` not `>=` |
| **COB** | Footer | "is above" | `>=` | Missing "or equal to" |
| **RecBolus** | Footer | "is above" | `>=` | Missing "or equal to" |
| **RecBolus** | Title | "More than" | `>=` | "More than" implies `>` not `>=` |
| **MissedBolus** (carbs) | Footer | "below" | ignores `<=` | Missing "or equal to" |
| **MissedBolus** (bolus) | Footer | "below" | ignores `<=` | Missing "or equal to" |

## Changes

### BatteryAlarmEditor.swift
- Footer: "drops below" → "drops to or below"

### COBAlarmEditor.swift
- InfoBanner: "exceeds" → "reaches or exceeds"
- Footer: "is above" → "is at or above"
- Title: "Above" → "At or Above"

### RecBolusAlarmEditor.swift
- Footer: "is above" → "is at or above"
- Title: "More than" → "At or Above"

### MissedBolusAlarmEditor.swift
- Ignore small boluses footer: "below" → "at or below"
- Ignore small boluses title: "Ignore below" → "Ignore at or below"
- Ignore small carbs footer: "below" → "at or below"
- Ignore small carbs title: "Below" → "At or Below"

## Logic Reference

| Alarm | Condition File | Logic | Now Matches UI |
|-------|----------------|-------|----------------|
| Battery | BatteryCondition.swift:14 | `level <= limit` | "to or below" |
| COB | COBCondition.swift:12 | `cob >= threshold` | "at or above" |
| RecBolus | RecBolusCondition.swift:16 | `rec >= threshold` | "at or above" |
| MissedBolus (carbs) | MissedBolusCondition.swift:37 | `carb.grams > minCarbGr` (ignores <=) | "at or below" |
| MissedBolus (bolus) | MissedBolusCondition.swift:55 | `bolus.units > minBolusU` (ignores <=) | "at or below" |

## Not Changed

The MissedBolus "Ignore low BG" section was already correct:
- Footer: "Only alert if the current BG is above this value."
- Logic: Fires when `BG > threshold` (strict greater than)

## Testing

1. Open each alarm editor and verify the updated text displays correctly:
   - Settings → Alarms → [Add or edit each alarm type]
   - Battery (Low Battery)
   - COB Alert
   - Rec. Bolus
   - Missed Bolus Alert


Note - no logic has been changed (so there are all 4 options, >, <, >=, <=) - whether it should be standardised so all alarms are >= or <= and the text updated to reflect that?