### PR TITLE
Fix for percentage string formating

### DIFF
--- a/LoopFollow/Controllers/MainViewController+updateStats.swift
+++ b/LoopFollow/Controllers/MainViewController+updateStats.swift
@@ -22,16 +22,16 @@ extension MainViewController {
 
             let stats = StatsData(bgData: lastDayOfData)
 
-            statsLowPercent.text = String(format: "%.1f%", stats.percentLow) + "%"
-            statsInRangePercent.text = String(format: "%.1f%", stats.percentRange) + "%"
-            statsHighPercent.text = String(format: "%.1f%", stats.percentHigh) + "%"
-            statsAvgBG.text = Localizer.toDisplayUnits(String(format: "%.0f%", stats.avgBG))
+            statsLowPercent.text = String(format: "%.1f%%", stats.percentLow)
+            statsInRangePercent.text = String(format: "%.1f%%", stats.percentRange)
+            statsHighPercent.text = String(format: "%.1f%%", stats.percentHigh)
+            statsAvgBG.text = Localizer.toDisplayUnits(String(format: "%.0f", stats.avgBG))
             if Storage.shared.useIFCC.value {
-                statsEstA1C.text = String(format: "%.0f%", stats.a1C)
+                statsEstA1C.text = String(format: "%.0f", stats.a1C)
             } else {
-                statsEstA1C.text = String(format: "%.1f%", stats.a1C)
+                statsEstA1C.text = String(format: "%.1f", stats.a1C)
             }
-            statsStdDev.text = String(format: "%.2f%", stats.stdDev)
+            statsStdDev.text = String(format: "%.2f", stats.stdDev)
 
             createStatsPie(pieData: stats.pie)
         }


### PR DESCRIPTION
### Summary of what was wrong and what was changed

#### Cause
In `String(format: ...)`, every `%` starts a format specifier.  
So in `"%.1f%"` the parser sees:

- `%.1f` → one `Float` / `Double`
- `%` → start of another specifier, but there’s no valid type after it

That mismatch is what triggers the warning/error:

> `Format '%.1f%' does not match expected '%f'`

---

### Changes in `MainViewController+updateStats.swift`

#### Percent labels (low / in range / high)

**From:**
`String(format: "%.1f%", ...) + "%"`

**To:**
`String(format: "%.1f%%", ...)`

Here `%%` is the correct way to render a literal `%`, so the output still shows e.g. `75.5%`.

---

#### `avgBG`, `A1C`, `stdDev`

These values are **not percentages**, so the trailing `%` in the format string was both incorrect and caused the same parsing issue.

The formats were changed to:

- `"%.0f"` for average BG and integer A1C
- `"%.1f"` for decimal A1C
- `"%.2f"` for standard deviation
