### PR TITLE
Restore default dark mode & fix migration for 3.x / 4.x users

### DIFF
--- a/LoopFollow/Storage/Storage+Migrate.swift
+++ b/LoopFollow/Storage/Storage+Migrate.swift
@@ -4,6 +4,14 @@
 import Foundation
 
 extension Storage {
+    func migrateStep3() {
+        let legacyForceDarkMode = StorageValue<Bool>(key: "forceDarkMode", defaultValue: true)
+        if legacyForceDarkMode.exists {
+            Storage.shared.appearanceMode.value = legacyForceDarkMode.value ? .dark : .system
+            legacyForceDarkMode.remove()
+        }
+    }
+
     func migrateStep2() {
         // Migrate from old system to new position-based system
         if remoteType.value != .none {
@@ -59,7 +67,6 @@ extension Storage {
 
         let legacyForceDarkMode = UserDefaultsValue<Bool>(key: "forceDarkMode", default: true)
         if legacyForceDarkMode.exists {
-            // Migrate from Bool to AppearanceMode: true -> .dark, false -> .system
             Storage.shared.appearanceMode.value = legacyForceDarkMode.value ? .dark : .system
             legacyForceDarkMode.setNil(key: "forceDarkMode")
         }

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -60,7 +60,7 @@ class Storage {
     // General Settings [BEGIN]
     var appBadge = StorageValue<Bool>(key: "appBadge", defaultValue: true)
     var colorBGText = StorageValue<Bool>(key: "colorBGText", defaultValue: true)
-    var appearanceMode = StorageValue<AppearanceMode>(key: "appearanceMode", defaultValue: .system)
+    var appearanceMode = StorageValue<AppearanceMode>(key: "appearanceMode", defaultValue: .dark)
     var showStats = StorageValue<Bool>(key: "showStats", defaultValue: true)
     var useIFCC = StorageValue<Bool>(key: "useIFCC", defaultValue: false)
     var showSmallGraph = StorageValue<Bool>(key: "showSmallGraph", defaultValue: true)

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -147,6 +147,11 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             Storage.shared.migrationStep.value = 2
         }
 
+        if Storage.shared.migrationStep.value < 3 {
+            Storage.shared.migrateStep3()
+            Storage.shared.migrationStep.value = 3
+        }
+
         // Synchronize info types to ensure arrays are the correct size
         synchronizeInfoTypes()
 


### PR DESCRIPTION
### Summary
This change restores **dark mode as the default appearance** and fixes a migration issue affecting users on **3.x and 4.x**.

Previously, the migration logic only handled users upgrading from **pre-3.0** versions. As a result, users already on 3.x or 4.x could lose their expected appearance setting during migration.

### What’s changed
- Restores **dark mode (`.dark`) as the default value** for `appearanceMode`
- Adds a new migration step to correctly handle:
  - Users coming from **3.x and 4.x**
  - Legacy `forceDarkMode` stored via `StorageValue`
- Ensures appearance is migrated consistently:
  - `true` → `.dark`
  - `false` → `.system`

### Why
- Dark mode was no longer the default
- Migration logic did not cover all upgrade paths, leading to incorrect appearance settings for existing users

### Impact
- No behavior change for users with an explicit appearance setting
- Correct and predictable migration for all users, regardless of upgrade path