### PR TITLE
update to fastlane_2.232.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "fastlane", "2.232.1"
+gem "fastlane", "2.232.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,17 +43,16 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+      multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-cookie_jar (0.0.8)
       faraday (>= 0.8.0)
@@ -62,8 +61,6 @@ GEM
     faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.2.0)
-      multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -71,7 +68,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.232.1)
+    fastlane (2.232.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -231,7 +228,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.1)
+  fastlane (= 2.232.2)
 
 BUNDLED WITH
   4.0.6


### PR DESCRIPTION
## Purpose:

Use the most recent version of fastlane, 2.232.2

## Method

1. Modify Gemfile for fastlane 2.232.2
2. in Terminal, use the command `bundle install`
3. commit the modified Gemfile and Gemfile.lock

## Test

✅ Ensure that Build_LoopFollow works on a fork with valid secrets, identifiers and certificates
✅ Manually remove push notifications from LoopFollow identifier and ensure it is restored by the Add_Identifiers action
