### PR TITLE
make the NUKE_CERT variables case insensitive

### DIFF
--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           CERT_STATUS_FILE="${{ github.workspace }}/fastlane/new_certificate_needed.txt"
           ENABLE_NUKE_CERTS=${{ vars.ENABLE_NUKE_CERTS }}
+          FORCE_NUKE_CERTS=${{ vars.FORCE_NUKE_CERTS }}
 
           if [ -f "$CERT_STATUS_FILE" ]; then
             CERT_STATUS=$(cat "$CERT_STATUS_FILE" | tr -d '\n' | tr -d '\r') # Read file content and strip newlines
@@ -70,19 +71,23 @@ jobs:
             echo "new_certificate_needed=false" >> $GITHUB_OUTPUT
           fi
 
-          # Check if ENABLE_NUKE_CERTS is not set to true when certs are valid
-          if [ "$CERT_STATUS" != "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+          # Normalize variables to lowercase for case-insensitive comparison
+          ENABLE_NUKE_CERTS_LC=$(echo "$ENABLE_NUKE_CERTS" | tr '[:upper:]' '[:lower:]')
+          FORCE_NUKE_CERTS_LC=$(echo "$FORCE_NUKE_CERTS" | tr '[:upper:]' '[:lower:]')
+
+          # Check if ENABLE_NUKE_CERTS_LC is not set to true when certs are valid
+          if [ "$CERT_STATUS" != "true" ] && [ "$ENABLE_NUKE_CERTS_LC" != "true" ]; then
             echo "::notice::🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
           fi
 
-          # Check if ENABLE_NUKE_CERTS is not set to true when certs are not valid
-          if [ "$CERT_STATUS" = "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+          # Check if ENABLE_NUKE_CERTS_LC is not set to true when certs are not valid
+          if [ "$CERT_STATUS" = "true" ] && [ "$ENABLE_NUKE_CERTS_LC" != "true" ]; then
             echo "::error::❌ No valid distribution certificate found. Automated renewal of certificates was skipped because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
             exit 1
           fi
 
-          # Check if vars.FORCE_NUKE_CERTS is not set to true
-          if [ vars.FORCE_NUKE_CERTS = "true" ]; then
+          # Check if FORCE_NUKE_CERTS_LC is set to true
+          if [ "$FORCE_NUKE_CERTS_LC" = "true" ]; then
             echo "::warning::‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'."
           fi
 


### PR DESCRIPTION
## Purpose:

Make the ENABLE_NUKE_CERTS and FORCE_NUKE_CERTS variables case insensitive.
* When entering a variable on my computer, it is natural to type `true`
* On my phone, the default is to begin whatever I type with a capital letter, causing `True` to be entered unless special care is taken

Several people have needed help to change their entries from `True` to `true`

This PR solves the issue.

## Method

Convert the variables to lower case internally before using them.
In addition, I changed var.FORCE_NUKE_CERTS to be treated like ENABLE_NUKE_CERTS

## Test

Test using dev branch and this PR to observe the effect of `true`, `True` and `TRUE`.
Realized during full testing that the FORCE_NUKE_CERT was already case insensitive with respect to whether nuking is forced
- not quite sure why that was happening 
- I plan to come back later and repeat the testing

Upon closer inspection, the messages are handled in one bit of the code and the action is handled in a different bit of the code. This only modifies the part of the code with the messages in `name: Set output and annotations based on Fastlane result` in the `create_certs` job. It does not affect the code in `nuke_certs` job.

| need cert? | ENABLE _NUKE_CERTS | FORCE _NUKE_CERTS | Status | Annotation |
|:--|:-:|:-:|:-:|:--|
| N | - | - | ✅ | 🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'. |
| N | True | - | ✅ | with dev branch, get warning |
| N | True | - | ✅ | with this PR, no annotation |
| Y | True | - | ❌ | use dev branch, action fails | 
| Y | True | - | ✅ | use this PR, get correct annotation: <br>Nuke certificates<br>✅ But don't worry about your existing TestFlight builds, they will keep working!<br>other expected messages |
| N | True | TRUE | ✅ | use dev branch - certs were forced - but no message about it|
| N | True | TRUE | ✅ | use this PR - <br>‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'. |
| N | True | False | ✅ | use this PR - no nuking and no warning |
| Y | True | False | ✅ | use this PR - <br>Nuke certificates]<br>✅ But don't worry about your existing TestFlight builds, they will keep working! |


