### PR TITLE
Remove unnecessary iOS version checks

### DIFF
--- a/LoopFollow/Extensions/EKEventStore+Extensions.swift
+++ b/LoopFollow/Extensions/EKEventStore+Extensions.swift
@@ -4,26 +4,16 @@
 import EventKit
 import Foundation
 
-#if swift(>=5.9)
-    extension EKEventStore {
-        func requestCalendarAccess(completion: @escaping (Bool, Error?) -> Void) {
-            if #available(iOS 17, *) {
-                requestFullAccessToEvents { granted, error in
-                    completion(granted, error)
-                }
-            } else {
-                requestAccess(to: .event) { granted, error in
-                    completion(granted, error)
-                }
+extension EKEventStore {
+    func requestCalendarAccess(completion: @escaping (Bool, Error?) -> Void) {
+        if #available(iOS 17, *) {
+            requestFullAccessToEvents { granted, error in
+                completion(granted, error)
             }
-        }
-    }
-#else
-    extension EKEventStore {
-        func requestCalendarAccess(completion: @escaping (Bool, Error?) -> Void) {
+        } else {
             requestAccess(to: .event) { granted, error in
                 completion(granted, error)
             }
         }
     }
-#endif
+}

--- a/LoopFollow/Settings/GeneralSettingsView.swift
+++ b/LoopFollow/Settings/GeneralSettingsView.swift
@@ -50,14 +50,12 @@ struct GeneralSettingsView: View {
                     Toggle("Snoozer emoji", isOn: $snoozerEmoji.value)
                     Toggle("Force portrait mode", isOn: $forcePortraitMode.value)
                         .onChange(of: forcePortraitMode.value) { _ in
-                            if #available(iOS 16.0, *) {
-                                let window = UIApplication.shared.connectedScenes
-                                    .compactMap { $0 as? UIWindowScene }
-                                    .flatMap { $0.windows }
-                                    .first
+                            let window = UIApplication.shared.connectedScenes
+                                .compactMap { $0 as? UIWindowScene }
+                                .flatMap { $0.windows }
+                                .first
 
-                                window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-                            }
+                            window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
                         }
                 }
 


### PR DESCRIPTION
## Summary
- Remove `if #available(iOS 16.0, *)` guard in `GeneralSettingsView.swift` — always true since the deployment target is iOS 16.6
- Remove `#if swift(>=5.9)` / `#else` wrapper in `EKEventStore+Extensions.swift` — Xcode versions supporting iOS 16.6 targets guarantee Swift 5.9+
- The `if #available(iOS 17, *)` check for `requestFullAccessToEvents` is kept since it guards an API above the deployment target