### PR TITLE
Improve TRC APNS push notification reliability

### DIFF
--- a/LoopFollow/Remote/TRC/PushMessage.swift
+++ b/LoopFollow/Remote/TRC/PushMessage.swift
@@ -4,9 +4,25 @@
 import Foundation
 
 struct EncryptedPushMessage: Encodable {
-    let aps: [String: Int] = ["content-available": 1]
-
+    let aps: APSPayload
     let encryptedData: String
+
+    init(encryptedData: String, commandType: TRCCommandType) {
+        self.encryptedData = encryptedData
+        aps = APSPayload(alert: "Remote Command: \(commandType.displayName)")
+    }
+
+    struct APSPayload: Encodable {
+        let contentAvailable: Int = 1
+        let interruptionLevel: String = "time-sensitive"
+        let alert: String
+
+        enum CodingKeys: String, CodingKey {
+            case contentAvailable = "content-available"
+            case interruptionLevel = "interruption-level"
+            case alert
+        }
+    }
 
     enum CodingKeys: String, CodingKey {
         case aps

--- a/LoopFollow/Remote/TRC/PushNotificationManager.swift
+++ b/LoopFollow/Remote/TRC/PushNotificationManager.swift
@@ -252,16 +252,17 @@ class PushNotificationManager {
             }
 
             let encryptedDataString = try messenger.encrypt(payload)
-            let finalMessage = EncryptedPushMessage(encryptedData: encryptedDataString)
+            let finalMessage = EncryptedPushMessage(encryptedData: encryptedDataString, commandType: payload.commandType)
 
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("bearer \(jwt)", forHTTPHeaderField: "authorization")
             request.setValue("application/json", forHTTPHeaderField: "content-type")
             request.setValue("10", forHTTPHeaderField: "apns-priority")
-            request.setValue("0", forHTTPHeaderField: "apns-expiration")
+            request.setValue("600", forHTTPHeaderField: "apns-expiration")
             request.setValue(bundleId, forHTTPHeaderField: "apns-topic")
-            request.setValue("background", forHTTPHeaderField: "apns-push-type")
+            request.setValue("alert", forHTTPHeaderField: "apns-push-type")
+            request.setValue(payload.commandType.rawValue, forHTTPHeaderField: "apns-collapse-id")
 
             request.httpBody = try JSONEncoder().encode(finalMessage)
 

--- a/LoopFollow/Remote/TRC/TRCCommandType.swift
+++ b/LoopFollow/Remote/TRC/TRCCommandType.swift
@@ -10,4 +10,15 @@ enum TRCCommandType: String, Encodable {
     case meal
     case startOverride = "start_override"
     case cancelOverride = "cancel_override"
+
+    var displayName: String {
+        switch self {
+        case .bolus: return "Bolus"
+        case .tempTarget: return "Temp Target"
+        case .cancelTempTarget: return "Cancel Temp Target"
+        case .meal: return "Meal"
+        case .startOverride: return "Start Override"
+        case .cancelOverride: return "Cancel Override"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Switch TRC push type from `background` to `alert` with visible notification text and `time-sensitive` interruption level
- Change `apns-expiration` from `0` (deliver now or discard) to `600` seconds (retry for 10 min, matching Trio's command validity window)
- Add `apns-collapse-id` to prevent duplicate command delivery during connectivity gaps

These changes address reports of remote commands not being received by Trio, especially on cellular or when the app is in the background. Silent/background pushes are aggressively throttled by iOS (blocked in Low Power Mode, limited to ~2-3/hour, not delivered after force-quit). Alert-type pushes with `time-sensitive` interruption level get reliable, immediate delivery.

No changes required on the Trio side — the same `didReceiveRemoteNotification` callback fires for both push types.