### PR TITLE
Update build to Xcode 26 / macOS 26 runner

### DIFF
--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -165,7 +165,7 @@ jobs:
   build:
     name: Build
     needs: [check_certs, check_status]
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
     if:
@@ -175,7 +175,7 @@ jobs:
         (vars.SCHEDULED_SYNC != 'false' && needs.check_status.outputs.NEW_COMMITS == 'true' )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
 
       - name: Checkout Repo for building
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Updates GitHub Actions build runner from `macos-15` to `macos-26`
- Updates Xcode from 16.4 to 26.2 (iOS 26 SDK)

Starting April 28, 2026, App Store Connect requires all iOS/iPadOS apps to be built with the iOS 26 SDK (included in Xcode 26+). This was flagged in the latest build delivery (ITMS-90725).

## Test plan
- [x] Trigger a manual build via workflow_dispatch and verify it completes successfully
- [x] Verify the built IPA uploads to TestFlight without SDK version warnings