### PR TITLE
Fix NUKE_CERT variables to be case insensitive in bash

### DIFF
--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -59,8 +59,9 @@ jobs:
         id: set_output
         run: |
           CERT_STATUS_FILE="${{ github.workspace }}/fastlane/new_certificate_needed.txt"
-          ENABLE_NUKE_CERTS=${{ vars.ENABLE_NUKE_CERTS }}
-          FORCE_NUKE_CERTS=${{ vars.FORCE_NUKE_CERTS }}
+          # Convert to lowercase for case-insensitive comparison
+          ENABLE_NUKE_CERTS=$(echo "${{ vars.ENABLE_NUKE_CERTS }}" | tr '[:upper:]' '[:lower:]')
+          FORCE_NUKE_CERTS=$(echo "${{ vars.FORCE_NUKE_CERTS }}" | tr '[:upper:]' '[:lower:]')
 
           if [ -f "$CERT_STATUS_FILE" ]; then
             CERT_STATUS=$(cat "$CERT_STATUS_FILE" | tr -d '\n' | tr -d '\r') # Read file content and strip newlines
@@ -72,19 +73,18 @@ jobs:
           fi
 
           # Check if ENABLE_NUKE_CERTS is not set to true when certs are valid
-          # Note: ${VAR,,} is bash syntax for lowercase conversion, ensuring case-insensitive comparison
-          if [ "$CERT_STATUS" != "true" ] && [ "${ENABLE_NUKE_CERTS,,}" != "true" ]; then
+          if [ "$CERT_STATUS" != "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
             echo "::notice::🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
           fi
 
           # Check if ENABLE_NUKE_CERTS is not set to true when certs are not valid
-          if [ "$CERT_STATUS" = "true" ] && [ "${ENABLE_NUKE_CERTS,,}" != "true" ]; then
+          if [ "$CERT_STATUS" = "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
             echo "::error::❌ No valid distribution certificate found. Automated renewal of certificates was skipped because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
             exit 1
           fi
 
           # Check if FORCE_NUKE_CERTS is set to true
-          if [ "${FORCE_NUKE_CERTS,,}" = "true" ]; then
+          if [ "$FORCE_NUKE_CERTS" = "true" ]; then
             echo "::warning::‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'."
           fi
 

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           CERT_STATUS_FILE="${{ github.workspace }}/fastlane/new_certificate_needed.txt"
           ENABLE_NUKE_CERTS=${{ vars.ENABLE_NUKE_CERTS }}
+          FORCE_NUKE_CERTS=${{ vars.FORCE_NUKE_CERTS }}
 
           if [ -f "$CERT_STATUS_FILE" ]; then
             CERT_STATUS=$(cat "$CERT_STATUS_FILE" | tr -d '\n' | tr -d '\r') # Read file content and strip newlines
@@ -71,18 +72,18 @@ jobs:
           fi
 
           # Check if ENABLE_NUKE_CERTS is not set to true when certs are valid
-          if [ "$CERT_STATUS" != "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+          if [ "$CERT_STATUS" != "true" ] && [ "${ENABLE_NUKE_CERTS,,}" != "true" ]; then
             echo "::notice::🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
           fi
 
           # Check if ENABLE_NUKE_CERTS is not set to true when certs are not valid
-          if [ "$CERT_STATUS" = "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+          if [ "$CERT_STATUS" = "true" ] && [ "${ENABLE_NUKE_CERTS,,}" != "true" ]; then
             echo "::error::❌ No valid distribution certificate found. Automated renewal of certificates was skipped because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
             exit 1
           fi
 
-          # Check if vars.FORCE_NUKE_CERTS is not set to true
-          if [ vars.FORCE_NUKE_CERTS = "true" ]; then
+          # Check if FORCE_NUKE_CERTS is set to true
+          if [ "${FORCE_NUKE_CERTS,,}" = "true" ]; then
             echo "::warning::‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'."
           fi
 

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -72,6 +72,7 @@ jobs:
           fi
 
           # Check if ENABLE_NUKE_CERTS is not set to true when certs are valid
+          # Note: ${VAR,,} is bash syntax for lowercase conversion, ensuring case-insensitive comparison
           if [ "$CERT_STATUS" != "true" ] && [ "${ENABLE_NUKE_CERTS,,}" != "true" ]; then
             echo "::notice::🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
           fi


### PR DESCRIPTION
## Summary
- Use `${VAR,,}` bash parameter expansion for case-insensitive comparisons instead of introducing `_LC` helper variables (supersedes #528)
- Fix bug where `FORCE_NUKE_CERTS` was compared as the literal string `vars.FORCE_NUKE_CERTS` instead of the actual variable value
- Add missing `FORCE_NUKE_CERTS=${{ vars.FORCE_NUKE_CERTS }}` assignment so bash has access to the variable
- No changes to the `nuke_certs` job `if:` condition since GitHub Actions `==` is already case-insensitive

## Test plan
- [ ] Set `ENABLE_NUKE_CERTS` to `True`, `TRUE`, and `true` — all should be recognized
- [ ] Set `FORCE_NUKE_CERTS` to `True`, `TRUE`, and `true` — all should trigger the force warning annotation
- [ ] Set `FORCE_NUKE_CERTS` to `false` or unset — no force warning annotation
- [ ] Verify the `nuke_certs` job still triggers correctly based on the GitHub Actions `if:` expression