### PR TITLE
Fix for singular matrix warning

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,25 @@ target 'LoopFollow' do
 
   pod 'Charts'
   pod 'ShareClient', :git => 'https://github.com/loopandlearn/dexcom-share-client-swift.git', :branch => 'loopfollow'
-  
+
+end
+
+post_install do |installer|
+  # Patch Charts Transformer to avoid "CGAffineTransformInvert: singular matrix"
+  # warnings when chart views have zero dimensions (before layout).
+  transformer = 'Pods/Charts/Source/Charts/Utils/Transformer.swift'
+  if File.exist?(transformer)
+    code = File.read(transformer)
+    original = 'return valueToPixelMatrix.inverted()'
+    patched = <<~SWIFT.chomp
+      let matrix = valueToPixelMatrix
+            guard matrix.a * matrix.d - matrix.b * matrix.c != 0 else {
+                return .identity
+            }
+            return matrix.inverted()
+    SWIFT
+    if code.include?(original)
+      File.write(transformer, code.sub(original, patched))
+    end
+  end
 end

--- a/Pods/Charts/Source/Charts/Utils/Transformer.swift
+++ b/Pods/Charts/Source/Charts/Utils/Transformer.swift
@@ -165,6 +165,11 @@ open class Transformer: NSObject
     
     @objc open var pixelToValueMatrix: CGAffineTransform
     {
-        return valueToPixelMatrix.inverted()
+        let matrix = valueToPixelMatrix
+        // Guard against singular matrix when chart has zero dimensions (before layout)
+        guard matrix.a * matrix.d - matrix.b * matrix.c != 0 else {
+            return .identity
+        }
+        return matrix.inverted()
     }
 }


### PR DESCRIPTION
This change prevents repeated console warnings:

`CGAffineTransformInvert: singular matrix`

These warnings occur when the Charts library attempts to invert a transform matrix while the chart view temporarily has zero dimensions (for example before layout is complete). In this situation the matrix is singular (determinant = 0), and calling `.inverted()` triggers the warning.

The fix adds a simple guard before performing the inversion. If the matrix determinant is zero, `.identity` is returned instead of attempting the inversion.

This is safe because a singular matrix means the chart has no meaningful size yet, so there is nothing useful to transform.

Since the code lives inside a CocoaPods dependency (`Charts`), the fix is applied in two ways:

- A direct patch in `Pods/Charts/Source/Charts/Utils/Transformer.swift`
- A `post_install` hook in the `Podfile` that re-applies the patch automatically when `pod install` runs

This removes the warnings without affecting chart rendering or behavior.