### PR TITLE
Add dragging lines to info display settings

### DIFF
--- a/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsView.swift
+++ b/LoopFollow/InfoDisplaySettings/InfoDisplaySettingsView.swift
@@ -19,25 +19,23 @@ struct InfoDisplaySettingsView: View {
                 }
 
                 Section(header: Text("Information Display Settings")) {
-                    List {
-                        ForEach(viewModel.infoSort, id: \.self) { sortedIndex in
-                            HStack {
-                                Text(viewModel.getName(for: sortedIndex))
-                                Spacer()
-                                Toggle("", isOn: Binding(
-                                    get: { viewModel.infoVisible[sortedIndex] },
-                                    set: { _ in
-                                        viewModel.toggleVisibility(for: sortedIndex)
-                                    }
-                                ))
-                                .labelsHidden()
-                            }
+                    ForEach(viewModel.infoSort, id: \.self) { sortedIndex in
+                        HStack {
+                            Text(viewModel.getName(for: sortedIndex))
+                            Spacer()
+                            Toggle("", isOn: Binding(
+                                get: { viewModel.infoVisible[sortedIndex] },
+                                set: { _ in
+                                    viewModel.toggleVisibility(for: sortedIndex)
+                                }
+                            ))
+                            .labelsHidden()
                         }
-                        .onMove(perform: viewModel.move)
                     }
-                    .environment(\.editMode, .constant(.active))
+                    .onMove(perform: viewModel.move)
                 }
             }
+            .environment(\.editMode, .constant(.active))
             .onDisappear {
                 NotificationCenter.default.post(name: NSNotification.Name("refresh"), object: nil)
             }


### PR DESCRIPTION
Added the three-line indicating that the rows can be rearranged to align with Tab Settings
<img width="1320" height="2868" alt="Preview 2026-03-16 22 10 27" src="https://github.com/user-attachments/assets/7f40e04c-b2af-4d3d-9909-1aaff75c3cc3" />
