### PR TITLE
Add removal dates to migration step comments

### DIFF
--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -145,25 +145,25 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         // Capture before migrations run: true for existing users, false for fresh installs.
         let isExistingUser = Storage.shared.migrationStep.exists
 
-        // Step 1: Merged to main 2025-06-07 (v3.0.0, 2025-07-07). Can be removed after 2026-07-07.
+        // Step 1: Released in v3.0.0 (2025-07-07). Can be removed after 2026-07-07.
         if Storage.shared.migrationStep.value < 1 {
             Storage.shared.migrateStep1()
             Storage.shared.migrationStep.value = 1
         }
 
-        // Step 2: Merged to main 2025-07-17 (v3.1.0, 2025-07-21). Can be removed after 2026-07-21.
+        // Step 2: Released in v3.1.0 (2025-07-21). Can be removed after 2026-07-21.
         if Storage.shared.migrationStep.value < 2 {
             Storage.shared.migrateStep2()
             Storage.shared.migrationStep.value = 2
         }
 
-        // Step 3: Merged to main 2026-03-20 (v5.0.0, 2026-03-20). Can be removed after 2027-03-20.
+        // Step 3: Released in v4.5.0 (2026-02-01). Can be removed after 2027-02-01.
         if Storage.shared.migrationStep.value < 3 {
             Storage.shared.migrateStep3()
             Storage.shared.migrationStep.value = 3
         }
 
-        // Step 4: Merged to main 2026-03-20 (v5.0.0, 2026-03-20). Can be removed after 2027-03-20.
+        // Step 4: Released in v5.0.0 (2026-03-20). Can be removed after 2027-03-20.
         if Storage.shared.migrationStep.value < 4 {
             // Existing users need to see the fat/protein order change banner.
             // New users never saw the old order, so mark it as already seen.
@@ -171,7 +171,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             Storage.shared.migrationStep.value = 4
         }
 
-        // Step 5: Merged to main 2026-03-20 (v5.0.0, 2026-03-20). Can be removed after 2027-03-20.
+        // Step 5: Released in v5.0.0 (2026-03-20). Can be removed after 2027-03-20.
         if Storage.shared.migrationStep.value < 5 {
             Storage.shared.migrateStep5()
             Storage.shared.migrationStep.value = 5


### PR DESCRIPTION
## Summary
- Added comments to each migration step documenting when it was first released and when it can safely be removed (one year after release)
- Step 1: removable after 2026-07-07
- Step 2: removable after 2026-07-21
- Step 3: removable after 2027-02-01
- Steps 4–5: removable after 2027-03-20