### PR TITLE
Clamp prediction values to 39-400 mg/dL

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -72,11 +72,9 @@ extension MainViewController {
                     while i <= toLoad {
                         if i < prediction.count {
                             let sgvValue = Int(round(prediction[i]))
-                            // Skip values higher than 600
-                            if sgvValue <= 600 {
-                                let prediction = ShareGlucoseData(sgv: sgvValue, date: predictionTime, direction: "flat")
-                                predictionData.append(prediction)
-                            }
+                            let clampedValue = min(max(sgvValue, 39), 400)
+                            let prediction = ShareGlucoseData(sgv: clampedValue, date: predictionTime, direction: "flat")
+                            predictionData.append(prediction)
                             predictionTime += 300
                         }
                         i += 1

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -72,7 +72,7 @@ extension MainViewController {
                     while i <= toLoad {
                         if i < prediction.count {
                             let sgvValue = Int(round(prediction[i]))
-                            let clampedValue = min(max(sgvValue, 39), 400)
+                            let clampedValue = min(max(sgvValue, globalVariables.minDisplayGlucose), globalVariables.maxDisplayGlucose)
                             let prediction = ShareGlucoseData(sgv: clampedValue, date: predictionTime, direction: "flat")
                             predictionData.append(prediction)
                             predictionTime += 300

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -182,7 +182,7 @@ extension MainViewController {
                                 minPredBG = min(minPredBG, predictionValue)
                                 maxPredBG = max(maxPredBG, predictionValue)
 
-                                let clampedValue = min(max(Int(round(predictionValue)), 39), 400)
+                                let clampedValue = min(max(Int(round(predictionValue)), globalVariables.minDisplayGlucose), globalVariables.maxDisplayGlucose)
                                 let prediction = ShareGlucoseData(sgv: clampedValue, date: predictionTime, direction: "flat")
                                 predictionData.append(prediction)
                                 predictionTime += 300

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -182,7 +182,8 @@ extension MainViewController {
                                 minPredBG = min(minPredBG, predictionValue)
                                 maxPredBG = max(maxPredBG, predictionValue)
 
-                                let prediction = ShareGlucoseData(sgv: Int(round(predictionValue)), date: predictionTime, direction: "flat")
+                                let clampedValue = min(max(Int(round(predictionValue)), 39), 400)
+                                let prediction = ShareGlucoseData(sgv: clampedValue, date: predictionTime, direction: "flat")
                                 predictionData.append(prediction)
                                 predictionTime += 300
                             }

--- a/LoopFollow/Helpers/Globals.swift
+++ b/LoopFollow/Helpers/Globals.swift
@@ -11,4 +11,11 @@ enum globalVariables {
     static let dotCarb: Float = 5
     static let dotBolus: Float = 5
     static let dotOther: Float = 5
+
+    // Glucose display range (mg/dL)
+    // Values at or below the min are shown as "LOW" on the main display;
+    // values at or above the max are shown as "HIGH". Also used to clamp
+    // prediction values on the graph.
+    static let minDisplayGlucose: Int = 39
+    static let maxDisplayGlucose: Int = 400
 }


### PR DESCRIPTION
## Summary

- Clamp prediction graph values to a range of 39–400 mg/dL to prevent extreme predictions (e.g. high COB) from blowing up the graph scale
- Applies to both Loop and OpenAPS (ZT, IOB, COB, UAM) predictions
- The min/max info display still shows unclamped values so the actual predicted range remains visible

Fixes #495