### PR TITLE
Display HIGH/LOW for out-of-range BG on main screen

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -242,9 +242,9 @@ extension MainViewController {
             // Set BGText with the latest BG value
             self.updateBGTextAppearance()
 
-            if latestBG <= 39 {
+            if latestBG <= globalVariables.minDisplayGlucose {
                 Observable.shared.bgText.value = "LOW"
-            } else if latestBG >= 400 {
+            } else if latestBG >= globalVariables.maxDisplayGlucose {
                 Observable.shared.bgText.value = "HIGH"
             } else {
                 Observable.shared.bgText.value = Localizer.toDisplayUnits(String(latestBG))

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -236,14 +236,19 @@ extension MainViewController {
             let latestBG = entries[latestEntryIndex].sgv
             let priorBG = entries[latestEntryIndex - 1].sgv
             let deltaBG = latestBG - priorBG
-            let lastBGTime = entries[latestEntryIndex].date
 
             self.updateServerText(with: sourceName)
 
             // Set BGText with the latest BG value
-            self.setBGTextColor()
+            self.updateBGTextAppearance()
 
-            Observable.shared.bgText.value = Localizer.toDisplayUnits(String(latestBG))
+            if latestBG <= 39 {
+                Observable.shared.bgText.value = "LOW"
+            } else if latestBG >= 400 {
+                Observable.shared.bgText.value = "HIGH"
+            } else {
+                Observable.shared.bgText.value = Localizer.toDisplayUnits(String(latestBG))
+            }
             Observable.shared.bg.value = latestBG
 
             // Direction handling

--- a/LoopFollow/Helpers/Globals.swift
+++ b/LoopFollow/Helpers/Globals.swift
@@ -11,4 +11,11 @@ enum globalVariables {
     static let dotCarb: Float = 5
     static let dotBolus: Float = 5
     static let dotOther: Float = 5
+
+    // Glucose display range (mg/dL)
+    // Values at or below the min are shown as "LOW" on the main display;
+    // values at or above the max are shown as "HIGH". Also used to clamp
+    // prediction values on the graph.
+    static let minDisplayGlucose: Int = 39
+    static let maxDisplayGlucose: Int = 400
 }

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -277,7 +277,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         Storage.shared.colorBGText.$value
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.setBGTextColor()
+                self?.updateBGTextAppearance()
             }
             .store(in: &cancellables)
 
@@ -1085,7 +1085,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         }
     }
 
-    func setBGTextColor() {
+    func updateBGTextAppearance() {
         if bgData.count > 0 {
             let latestBG = bgData[bgData.count - 1].sgv
             var color = NSUIColor.label
@@ -1105,6 +1105,12 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             }
 
             BGText.textColor = color
+
+            if latestBG <= 39 || latestBG >= 400 {
+                BGText.font = UIFont.systemFont(ofSize: 65, weight: .black)
+            } else {
+                BGText.font = UIFont.systemFont(ofSize: 85, weight: .black)
+            }
         }
     }
 

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -1106,7 +1106,7 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
 
             BGText.textColor = color
 
-            if latestBG <= 39 || latestBG >= 400 {
+            if latestBG <= globalVariables.minDisplayGlucose || latestBG >= globalVariables.maxDisplayGlucose {
                 BGText.font = UIFont.systemFont(ofSize: 65, weight: .black)
             } else {
                 BGText.font = UIFont.systemFont(ofSize: 85, weight: .black)


### PR DESCRIPTION
## Summary
- Show "HIGH" when BG >= 400 and "LOW" when BG <= 39 on the main screen, matching Dexcom sensor range behavior
- Reduce font size (85pt → 65pt) when displaying HIGH/LOW so the text fits
- Rename `setBGTextColor` → `updateBGTextAppearance` to reflect its broader role

Closes #503