### PR TITLE
Fix LA not refreshing on foreground after stale overlay

### DIFF
--- a/LoopFollow/LiveActivity/LiveActivityManager.swift
+++ b/LoopFollow/LiveActivity/LiveActivityManager.swift
@@ -120,6 +120,7 @@ final class LiveActivityManager {
         // new LA is started computes showRenewalOverlay = false.
         Storage.shared.laRenewBy.value = 0
         Storage.shared.laRenewalFailed.value = false
+        cancelRenewalFailedNotification()
 
         guard let activity = current else {
             startFromCurrentState()
@@ -189,6 +190,28 @@ final class LiveActivityManager {
         }
 
         if let existing = Activity<GlucoseLiveActivityAttributes>.activities.first {
+            // Before reusing, check whether this activity needs a restart. This covers cold
+            // starts (app was killed while the overlay was showing — willEnterForeground is
+            // never sent, so handleForeground never runs) and any other path that lands here
+            // without first going through handleForeground.
+            let renewBy = Storage.shared.laRenewBy.value
+            let now = Date().timeIntervalSince1970
+            let staleDatePassed = existing.content.staleDate.map { $0 <= Date() } ?? false
+            let inRenewalWindow = renewBy > 0 && now >= renewBy - LiveActivityManager.renewalWarning
+            let needsRestart = Storage.shared.laRenewalFailed.value || inRenewalWindow || staleDatePassed
+
+            if needsRestart {
+                LogManager.shared.log(category: .general, message: "[LA] existing activity is stale on startIfNeeded — ending and restarting (staleDatePassed=\(staleDatePassed), inRenewalWindow=\(inRenewalWindow))")
+                Storage.shared.laRenewBy.value = 0
+                Storage.shared.laRenewalFailed.value = false
+                cancelRenewalFailedNotification()
+                Task {
+                    await existing.end(nil, dismissalPolicy: .immediate)
+                    await MainActor.run { self.startIfNeeded() }
+                }
+                return
+            }
+
             bind(to: existing, logReason: "reuse")
             Storage.shared.laRenewalFailed.value = false
             return


### PR DESCRIPTION
## Summary

- **`startIfNeeded()` reused stale activities on cold start** — when the app is killed while the renewal overlay is showing, `willEnterForeground` is never sent on relaunch, so `handleForeground()` never runs. The cold-start path (`viewDidAppear → startFromCurrentState → startIfNeeded`) found the existing stale activity and rebound to it, leaving the overlay visible. Fix: before reusing an existing activity, check `existing.content.staleDate` and the renewal window; if stale, end it (awaited) and restart.
- **"Live Activity Expiring" notification not cleared on foreground restart** — `handleForeground()` cleared `laRenewalFailed` and `laRenewBy` but never called `cancelRenewalFailedNotification()`, leaving the system notification visible after the LA successfully restarted.

## Test plan

- [ ] Let the LA run until the renewal overlay appears (or advance the clock), then force-quit the app. Relaunch — the LA should restart automatically without needing the Restart button.
- [ ] Let the LA run until the renewal overlay appears, background the app, then foreground it — the LA should restart and the "Live Activity Expiring" notification should be dismissed.
- [ ] Tap the Restart button — unchanged behaviour, LA restarts and notification clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)