### PR TITLE
Fix stale overlay tap + redesign expanded Dynamic Island

### DIFF
--- a/LoopFollow/LiveActivity/LAAppGroupSettings.swift
+++ b/LoopFollow/LiveActivity/LAAppGroupSettings.swift
@@ -147,8 +147,6 @@ enum LAAppGroupSettings {
         static let highLineMgdl = "la.highLine.mgdl"
         static let slots = "la.slots"
         static let smallWidgetSlot = "la.smallWidgetSlot"
-        static let watchEnabled = "la.watchEnabled"
-        static let carPlayEnabled = "la.carPlayEnabled"
         static let displayName = "la.displayName"
         static let showDisplayName = "la.showDisplayName"
     }
@@ -206,34 +204,6 @@ enum LAAppGroupSettings {
             return LiveActivitySlotDefaults.smallWidgetSlot
         }
         return LiveActivitySlotOption(rawValue: raw) ?? LiveActivitySlotDefaults.smallWidgetSlot
-    }
-
-    // MARK: - Watch / CarPlay enabled (Write)
-
-    static func setWatchEnabled(_ enabled: Bool) {
-        defaults?.set(enabled, forKey: Keys.watchEnabled)
-    }
-
-    static func setCarPlayEnabled(_ enabled: Bool) {
-        defaults?.set(enabled, forKey: Keys.carPlayEnabled)
-    }
-
-    // MARK: - Watch / CarPlay enabled (Read)
-
-    /// Whether the Watch Smart Stack Live Activity is enabled.
-    /// Detected at render time by canvas height (≤ 75 pt → Watch).
-    /// Defaults to `true`.
-    static func watchEnabled() -> Bool {
-        guard defaults?.object(forKey: Keys.watchEnabled) != nil else { return true }
-        return defaults?.bool(forKey: Keys.watchEnabled) ?? true
-    }
-
-    /// Whether the CarPlay Dashboard Live Activity is enabled.
-    /// Detected at render time by canvas height (> 75 pt → CarPlay).
-    /// Defaults to `true`.
-    static func carPlayEnabled() -> Bool {
-        guard defaults?.object(forKey: Keys.carPlayEnabled) != nil else { return true }
-        return defaults?.bool(forKey: Keys.carPlayEnabled) ?? true
     }
 
     // MARK: - Display Name

--- a/LoopFollow/LiveActivitySettingsView.swift
+++ b/LoopFollow/LiveActivitySettingsView.swift
@@ -8,8 +8,6 @@ struct LiveActivitySettingsView: View {
     @State private var restartConfirmed = false
     @State private var slots: [LiveActivitySlotOption] = LAAppGroupSettings.slots()
     @State private var smallWidgetSlot: LiveActivitySlotOption = LAAppGroupSettings.smallWidgetSlot()
-    @State private var watchEnabled: Bool = LAAppGroupSettings.watchEnabled()
-    @State private var carPlayEnabled: Bool = LAAppGroupSettings.carPlayEnabled()
 
     private let slotLabels = ["Top left", "Top right", "Bottom left", "Bottom right"]
 
@@ -45,37 +43,17 @@ struct LiveActivitySettingsView: View {
                 }
             }
 
-            Section(header: Text("CarPlay / Watch Smart Stack")) {
-                Toggle("Show on Apple Watch", isOn: Binding(
-                    get: { watchEnabled },
+            Section(header: Text("Grid Slot - CarPlay / Watch")) {
+                Picker("Right slot", selection: Binding(
+                    get: { smallWidgetSlot },
                     set: { newValue in
-                        watchEnabled = newValue
-                        LAAppGroupSettings.setWatchEnabled(newValue)
-                        LiveActivityManager.shared.forceRestart()
+                        smallWidgetSlot = newValue
+                        LAAppGroupSettings.setSmallWidgetSlot(newValue)
+                        LiveActivityManager.shared.refreshFromCurrentState(reason: "small widget slot changed")
                     }
-                ))
-
-                Toggle("Show on CarPlay", isOn: Binding(
-                    get: { carPlayEnabled },
-                    set: { newValue in
-                        carPlayEnabled = newValue
-                        LAAppGroupSettings.setCarPlayEnabled(newValue)
-                        LiveActivityManager.shared.forceRestart()
-                    }
-                ))
-
-                if watchEnabled || carPlayEnabled {
-                    Picker("Right slot", selection: Binding(
-                        get: { smallWidgetSlot },
-                        set: { newValue in
-                            smallWidgetSlot = newValue
-                            LAAppGroupSettings.setSmallWidgetSlot(newValue)
-                            LiveActivityManager.shared.refreshFromCurrentState(reason: "small widget slot changed")
-                        }
-                    )) {
-                        ForEach(LiveActivitySlotOption.allCases, id: \.self) { option in
-                            Text(option.displayName).tag(option)
-                        }
+                )) {
+                    ForEach(LiveActivitySlotOption.allCases, id: \.self) { option in
+                        Text(option.displayName).tag(option)
                     }
                 }
             }

--- a/LoopFollowLAExtension/LoopFollowLiveActivity.swift
+++ b/LoopFollowLAExtension/LoopFollowLiveActivity.swift
@@ -102,25 +102,8 @@ private struct LockScreenFamilyAdaptiveView: View {
 
     var body: some View {
         if activityFamily == .small {
-            // Use canvas WIDTH to distinguish Watch Smart Stack from CarPlay Dashboard.
-            // The widest Apple Watch (Ultra 2, 49 mm) is ~183 pt wide; CarPlay displays
-            // are always considerably wider (minimum ~250 pt on the most compact screens).
-            // A 210 pt threshold gives a ≈14 % buffer above the max Watch width.
-            // Height is avoided because system padding can push the watch canvas above
-            // simple height-only thresholds depending on the watch model.
-            // Color.black (not Color.clear) is used when disabled so old cached renders
-            // do not show through the transparent layer on Watch.
-            GeometryReader { geo in
-                let isWatch = geo.size.width < 210
-                let enabled = isWatch ? LAAppGroupSettings.watchEnabled() : LAAppGroupSettings.carPlayEnabled()
-                if enabled {
-                    SmallFamilyView(snapshot: state.snapshot)
-                        .frame(width: geo.size.width, height: geo.size.height)
-                } else {
-                    Color.black
-                }
-            }
-            .activityBackgroundTint(Color.black.opacity(0.25))
+            SmallFamilyView(snapshot: state.snapshot)
+                .activityBackgroundTint(Color.black.opacity(0.25))
         } else {
             LockScreenLiveActivityView(state: state)
                 .activityBackgroundTint(LAColors.backgroundTint(for: state.snapshot))
@@ -416,26 +399,19 @@ private struct DynamicIslandLeadingView: View {
                 .minimumScaleFactor(0.7)
         } else {
             VStack(alignment: .leading, spacing: 2) {
-                Text(LAFormat.glucose(snapshot))
-                    .font(.system(size: 28, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(.white)
-
-                HStack(spacing: 5) {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(LAFormat.glucose(snapshot))
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(LAColors.keyline(for: snapshot))
                     Text(LAFormat.trendArrow(snapshot))
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.white.opacity(0.9))
-
-                    Text(LAFormat.delta(snapshot))
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .monospacedDigit()
-                        .foregroundStyle(.white.opacity(0.9))
-
-                    Text("Proj: \(LAFormat.projected(snapshot))")
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .monospacedDigit()
-                        .foregroundStyle(.white.opacity(0.9))
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundStyle(LAColors.keyline(for: snapshot))
                 }
+                Text("\(LAFormat.delta(snapshot)) \(snapshot.unit.displayName)")
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(.white.opacity(0.85))
             }
         }
     }
@@ -448,18 +424,21 @@ private struct DynamicIslandTrailingView: View {
         if snapshot.isNotLooping {
             EmptyView()
         } else {
-            VStack(alignment: .trailing, spacing: 3) {
-                Text("IOB \(LAFormat.iob(snapshot))")
-                    .font(.system(size: 13, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(.white.opacity(0.95))
-
-                Text("COB \(LAFormat.cob(snapshot))")
-                    .font(.system(size: 13, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(.white.opacity(0.95))
+            let slot = LAAppGroupSettings.smallWidgetSlot()
+            if slot != .none {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(slot.gridLabel)
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.65))
+                    Text(slotFormattedValue(option: slot, snapshot: snapshot))
+                        .font(.system(size: 18, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+                .padding(.trailing, 6)
             }
-            .padding(.trailing, 6)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Fix stale overlay tap**: Introduced `endingForRestart` flag in `LiveActivityManager` to prevent a race condition where tapping a stale Live Activity overlay would set `dismissedByUser = true`, permanently stopping auto-restart. The flag is set synchronously before `activity.end()` and cleared after the restart completes, so the state observer ignores our own programmatic dismissal.

- **Redesign expanded Dynamic Island**: The expanded DI leading view now matches the CarPlay/Watch SmallFamilyView layout — glucose value + trend arrow (color-keyed) with delta+unit below. The trailing view shows the configurable `smallWidgetSlot` metric (label + value) instead of hardcoded IOB/COB. The bottom "Updated at" banner is unchanged.

- **Remove Watch/CarPlay toggles**: Removed per-surface enable/disable toggles. No viable runtime API exists to distinguish Watch Smart Stack from CarPlay at render time without requiring iOS 26 minimum. The settings UI retains the slot picker for the right-side metric on both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)