### PR TITLE
Add workflow to warn PRs targeting main

### DIFF
--- a/.github/workflows/warn_main_pr.yml
+++ b/.github/workflows/warn_main_pr.yml
@@ -1,0 +1,27 @@
+name: Warn PR targets main
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  warn:
+    if: github.repository_owner == 'loopandlearn'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '⚠️ This PR targets the `main` branch. We do not accept PRs directly to `main` — please retarget your PR to the `dev` branch instead.'
+            });

--- a/.github/workflows/warn_main_pr.yml
+++ b/.github/workflows/warn_main_pr.yml
@@ -1,8 +1,8 @@
 name: Warn PR targets main
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, edited]
     branches:
       - main
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that triggers when a PR is opened against `main`
- Automatically comments warning the author to retarget their PR to `dev`
- Runs on `ubuntu-latest`, consistent with other lightweight workflows