### PR TITLE
Fix TRC bolus command not received by Trio

### DIFF
--- a/LoopFollow/Remote/TRC/PushMessage.swift
+++ b/LoopFollow/Remote/TRC/PushMessage.swift
@@ -7,20 +7,16 @@ struct EncryptedPushMessage: Encodable {
     let aps: APSPayload
     let encryptedData: String
 
-    init(encryptedData: String, commandType: TRCCommandType) {
+    init(encryptedData: String, commandType _: TRCCommandType) {
         self.encryptedData = encryptedData
-        aps = APSPayload(alert: "Remote Command: \(commandType.displayName)")
+        aps = APSPayload()
     }
 
     struct APSPayload: Encodable {
         let contentAvailable: Int = 1
-        let interruptionLevel: String = "time-sensitive"
-        let alert: String
 
         enum CodingKeys: String, CodingKey {
             case contentAvailable = "content-available"
-            case interruptionLevel = "interruption-level"
-            case alert
         }
     }
 

--- a/LoopFollow/Remote/TRC/PushNotificationManager.swift
+++ b/LoopFollow/Remote/TRC/PushNotificationManager.swift
@@ -258,10 +258,10 @@ class PushNotificationManager {
             request.httpMethod = "POST"
             request.setValue("bearer \(jwt)", forHTTPHeaderField: "authorization")
             request.setValue("application/json", forHTTPHeaderField: "content-type")
-            request.setValue("10", forHTTPHeaderField: "apns-priority")
+            request.setValue("5", forHTTPHeaderField: "apns-priority")
             request.setValue("600", forHTTPHeaderField: "apns-expiration")
             request.setValue(bundleId, forHTTPHeaderField: "apns-topic")
-            request.setValue("alert", forHTTPHeaderField: "apns-push-type")
+            request.setValue("background", forHTTPHeaderField: "apns-push-type")
             request.setValue(payload.commandType.rawValue, forHTTPHeaderField: "apns-collapse-id")
 
             request.httpBody = try JSONEncoder().encode(finalMessage)


### PR DESCRIPTION
## Summary

- Switch TRC push notifications from `apns-push-type: alert` (priority 10) to `apns-push-type: background` (priority 5)
- Remove `alert` and `interruption-level` fields from the APNS payload

## Problem

Remote bolus commands sent via Trio Remote Control appeared to succeed (APNS returned 200) but Trio never received or acted on them. Trio's logs showed no trace of an incoming push notification.

The root cause: when `apns-push-type: alert` is used, iOS silently drops the notification if the receiving app (Trio) has not been granted notification permissions by the user. The command never reached `AppDelegate.didReceiveRemoteNotification`.

## Fix

Background push notifications (`content-available: 1`, `apns-push-type: background`, priority 5) are delivered by iOS regardless of notification permission status, which is the correct mechanism for remote command delivery. This matches Apple's documentation requirements — priority 5 is mandatory when using `apns-push-type: background`.

## Test plan

- [x] Send a remote bolus from LoopFollow (TRC) to a Trio device that has notification permissions denied
- [x] Confirm Trio receives and processes the command
- [x] Confirm APNS still returns 200
- [x] Verify other TRC commands (temp target, meal, override) also work