### PR TITLE
Bump addressable from 2.8.8 to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)


### PR DESCRIPTION
## Summary

- Updates the `addressable` gem in `Gemfile.lock` from 2.8.8 to 2.9.0 to resolve Dependabot alert [14](https://github.com/loopandlearn/LoopFollow/security/dependabot/14).
- Fixes [GHSA-h27x-rffw-24p4](https://github.com/advisories/GHSA-h27x-rffw-24p4) / CVE-2026-35611, a high-severity (CVSS 7.5) ReDoS vulnerability in Addressable's URI template matching caused by catastrophic backtracking in generated regular expressions.
- `addressable` is a transitive dependency of `fastlane`; the fix is a pure lockfile bump with no `Gemfile` changes.