### PR TITLE
Route remote command polling through TaskScheduler

### DIFF
--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -12,6 +12,7 @@ enum TaskID: CaseIterable {
     case minAgoUpdate
     case calendarWrite
     case alarmCheck
+    case remoteCommandPoll
 }
 
 struct ScheduledTask {

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -169,7 +169,6 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
         "deviceStatus": false,
     ]
     private var loadingTimeoutTimer: Timer?
-    private var remoteCommandPollingTimer: Timer?
     private var remoteCommandPollingStartedAt: Date?
     private var remoteCommandPollingBaseline: RemoteCommandDataSignature?
     private let remoteCommandPollingInterval: TimeInterval = 3
@@ -869,7 +868,6 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     }
 
     deinit {
-        remoteCommandPollingTimer?.invalidate()
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name("refresh"), object: nil)
     }
 
@@ -915,26 +913,20 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
 
         remoteCommandPollingBaseline = currentRemoteCommandDataSignature()
         remoteCommandPollingStartedAt = Date()
-        remoteCommandPollingTimer?.invalidate()
 
-        performRemoteCommandPollingTick()
-
-        let timer = Timer.scheduledTimer(withTimeInterval: remoteCommandPollingInterval, repeats: true) { [weak self] _ in
+        TaskScheduler.shared.scheduleTask(id: .remoteCommandPoll, nextRun: Date()) { [weak self] in
             self?.performRemoteCommandPollingTick()
         }
-        timer.tolerance = 0.5
-        remoteCommandPollingTimer = timer
 
         LogManager.shared.log(category: .general, message: "Started aggressive polling after remote command result notification")
     }
 
     private func stopRemoteCommandPolling(reason: String) {
-        guard remoteCommandPollingTimer != nil || remoteCommandPollingStartedAt != nil else { return }
+        guard remoteCommandPollingStartedAt != nil else { return }
 
-        remoteCommandPollingTimer?.invalidate()
-        remoteCommandPollingTimer = nil
         remoteCommandPollingStartedAt = nil
         remoteCommandPollingBaseline = nil
+        TaskScheduler.shared.rescheduleTask(id: .remoteCommandPoll, to: .distantFuture)
 
         LogManager.shared.log(category: .general, message: "Stopped aggressive polling: \(reason)")
     }
@@ -947,9 +939,14 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             return
         }
 
-        bgTaskAction()
-        deviceStatusAction()
-        treatmentsTaskAction()
+        let now = Date()
+        TaskScheduler.shared.rescheduleTask(id: .deviceStatus, to: now)
+        TaskScheduler.shared.rescheduleTask(id: .treatments, to: now)
+
+        TaskScheduler.shared.rescheduleTask(
+            id: .remoteCommandPoll,
+            to: Date().addingTimeInterval(remoteCommandPollingInterval)
+        )
     }
 
     private func currentRemoteCommandDataSignature() -> RemoteCommandDataSignature {


### PR DESCRIPTION
## Summary
- Replaces the parallel `Timer.scheduledTimer` used for post-remote-command polling with a new `.remoteCommandPoll` `TaskScheduler` task, so the aggressive polling runs through the same scheduler as every other recurring fetch in the app.
- The tick reschedules `.deviceStatus` and `.treatments` to fire immediately and reschedules itself for the next 3s interval. The task is parked at `.distantFuture` when the window closes (timeout or fresh data detected) — the same transient resting state every task already passes through between fire and reschedule.
- Drops `.fetchBG` from the polled set: no remote command produces a BG entry, and `RemoteCommandDataSignature` doesn't inspect `bgData`, so the fetch was dead weight during the window.

## Why
- Avoids having two independent timing mechanisms running during the 30s window. Previously the parallel `Timer` called `bgTaskAction`/`deviceStatusAction`/`treatmentsTaskAction` directly every 3s, each of which internally `rescheduleTask`'d itself back to its normal cadence — a continuous double-reschedule war.
- Uniform app backgrounding behavior: if the app backgrounds mid-window, `TaskScheduler`'s lifecycle applies; no separate `Timer` lifecycle to reason about.
- No `deinit` timer invalidation needed — `TaskScheduler` owns the lifetime.

## Safety notes
- `.remoteCommandPoll` is lazily registered only when `startRemoteCommandPolling` is called from the `.remoteCommandSucceeded` notification. `scheduleAllTasks()` is not touched, so no app refresh/reset path will accidentally spawn it.
- `TaskID.allCases` is only iterated in `fireOverdueTasks`, which filters on `nextRun <= now`. A parked `.distantFuture` entry is skipped forever until an explicit `rescheduleTask` revives it.
- `MainViewController` is the app root VC, but the `scheduleTask` closure uses `[weak self]` as a belt-and-suspenders guard against any future refactor that deinits it.