### PR TITLE
Fix dev build: re-declare lastBGTime local in viewUpdateNSBG

### DIFF
--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -236,6 +236,7 @@ extension MainViewController {
             let latestBG = entries[latestEntryIndex].sgv
             let priorBG = entries[latestEntryIndex - 1].sgv
             let deltaBG = latestBG - priorBG
+            let lastBGTime = entries[latestEntryIndex].date
 
             self.updateServerText(with: sourceName)
 


### PR DESCRIPTION
## Summary

- Re-adds `let lastBGTime = entries[latestEntryIndex].date` in `BGData.swift` `viewUpdateNSBG`. Dev currently fails to compile with `Cannot find 'lastBGTime' in scope`.

## Why this happened

Two PRs merged into `dev` on the same day (2026-04-09) within ~28 minutes, textually non-conflicting but semantically interfering:

- **#537 Live activity** (06:58 PDT) added `Storage.shared.lastBgReadingTimeSeconds.value = lastBGTime` later in the function, relying on the existing local `let lastBGTime`.
- **#565 Display HIGH/LOW for out-of-range BG on main screen** (07:26 PDT) removed the `let lastBGTime = entries[latestEntryIndex].date` declaration as part of an unrelated refactor — the #565 branch was cut before #537 landed, so from its perspective the local was unused.

Both PRs modified different regions of `viewUpdateNSBG`, so git's 3-way merge produced a syntactically clean file — but the surviving reference now dangles. Neither PR's CI caught it because each was built against an older base.

## Impact

`lastBgReadingTimeSeconds` has exactly one writer (this broken line) and one reader (`StorageCurrentGlucoseStateProvider.updatedAt`, which drives the Live Activity / Watch complication "updated at" timestamp). Restoring the write is the minimal fix.