### PR TITLE
Add SwiftFormat lint check on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+run-name: Lint (${{ github.head_ref || github.ref_name }})
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  swiftformat:
+    name: SwiftFormat
+    runs-on: ubuntu-latest
+    container: swift:6.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache SwiftFormat build
+        uses: actions/cache@v4
+        with:
+          path: BuildTools/.build
+          key: ${{ runner.os }}-swiftformat-${{ hashFiles('BuildTools/Package.resolved', 'BuildTools/Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftformat-
+
+      - name: SwiftFormat --lint
+        run: |
+          swift run -c release --package-path BuildTools swiftformat . \
+            --lint \
+            --header "LoopFollow\n{file}" \
+            --exclude Pods,Generated,R.generated.swift,fastlane/swift,Dependencies,dexcom-share-client-swift

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds a `Lint` workflow that runs `swiftformat --lint` on every pull request.

## What it does

- Runs on `ubuntu-latest` inside the official `swift:6.0` container — no macOS minutes consumed.
- Builds SwiftFormat from `BuildTools/Package.swift` so the CI version is always the same pin developers use locally (currently `0.56.1`). No separate config to drift.
- Same `--header` and `--exclude` flags as `Scripts/swiftformat.sh`, so whatever passes locally passes in CI.
- `--lint` mode: reports violations and exits non-zero without rewriting any files. The PR check goes red; the contributor runs `swiftformat` locally and pushes the fix themselves. CI never commits back over a contributor's branch.
- `BuildTools/.build` is cached by `Package.resolved` hash — first run compiles SwiftFormat (~2–3 min), subsequent runs are <30s.

## Why not auto-fix and commit back

- The default `GITHUB_TOKEN` can't push to fork PRs, so any auto-fix path requires a PAT with push rights — a real security footgun for a lint job.
- Race conditions: CI commits a format fix while the contributor is pushing a real commit, and the contributor has to rebase over a change they didn't author.
- `git blame` and commit authorship get muddied by bot commits.
- A failing check teaches the contributor to run the formatter locally; a silent auto-fix teaches them nothing.

## Enabling as a required check

The workflow only *reports* status. To actually block merges on lint failures, the check needs to be marked **Required** in branch protection (Settings → Branches → `dev` → "Require status checks to pass before merging" → add `Lint / SwiftFormat`). GitHub only lets you require checks it has seen run at least once, so this should be done after the first successful run on this PR.