### PR TITLE
Clamp BG graph to HIGH/LOW display range

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -801,10 +801,14 @@ extension MainViewController {
 
         topBG = Storage.shared.minBGScale.value
         for i in 0 ..< entries.count {
-            if Double(entries[i].sgv) > topBG - maxBGOffset {
-                topBG = Double(entries[i].sgv) + maxBGOffset
+            // Clamp the plotted y-value to the same bounds the header text uses
+            // (HIGH/LOW), so the graph stays consistent with the main display.
+            // The pill tooltip still shows the raw reading.
+            let plottedSgv = Double(min(max(entries[i].sgv, globalVariables.minDisplayGlucose), globalVariables.maxDisplayGlucose))
+            if plottedSgv > topBG - maxBGOffset {
+                topBG = plottedSgv + maxBGOffset
             }
-            let value = ChartDataEntry(x: Double(entries[i].date), y: Double(entries[i].sgv), data: formatPillText(line1: Localizer.toDisplayUnits(String(entries[i].sgv)), time: entries[i].date))
+            let value = ChartDataEntry(x: Double(entries[i].date), y: plottedSgv, data: formatPillText(line1: Localizer.toDisplayUnits(String(entries[i].sgv)), time: entries[i].date))
             mainChart.append(value)
             smallChart.append(value)
 

--- a/LoopFollow/Helpers/Globals.swift
+++ b/LoopFollow/Helpers/Globals.swift
@@ -15,7 +15,7 @@ enum globalVariables {
     // Glucose display range (mg/dL)
     // Values at or below the min are shown as "LOW" on the main display;
     // values at or above the max are shown as "HIGH". Also used to clamp
-    // prediction values on the graph.
+    // BG readings and prediction values on the graph.
     static let minDisplayGlucose: Int = 39
     static let maxDisplayGlucose: Int = 400
 }


### PR DESCRIPTION
## Summary

When a Nightscout reading exceeds `maxDisplayGlucose` (400 mg/dL), the main header correctly shows **HIGH** but the chart plots the raw value (e.g. 550) and autoscales the y-axis up to 600. This makes the chart inconsistent with the header text.

This PR clamps the plotted y-value in `updateBGGraph` to `[minDisplayGlucose, maxDisplayGlucose]` (39–400 mg/dL) so the chart line stays within the range the header represents. The pill tooltip still shows the raw reading so the exact value is accessible on tap.

- Chart-only change — `bgData`, stats, alarms, and color coding are unaffected.
- Predictions were already clamped to these bounds upstream (`DeviceStatusLoop`, `DeviceStatusOpenAPS`), so the graph is now consistent across both data types.
- Updated the `Globals.swift` comment to reflect the broader usage of the constants.