### PR TITLE
Skip volume-button stop teardown when monitoring was never started

### DIFF
--- a/LoopFollow/Controllers/VolumeButtonHandler.swift
+++ b/LoopFollow/Controllers/VolumeButtonHandler.swift
@@ -106,7 +106,7 @@ class VolumeButtonHandler: NSObject {
     }
 
     private func alarmStopped() {
-        LogManager.shared.log(category: .volumeButtonSnooze, message: "Alarm stop detected")
+        guard isMonitoring else { return }
 
         alarmStartTime = nil
         stopMonitoring()


### PR DESCRIPTION
## Summary

`VolumeButtonHandler.alarmStopped()` was always logging `[Volume Button Snooze] Alarm stop detected` and running its teardown on every alarm event — even when the volume-button-snooze feature was disabled and the matching `alarmStarted()` had early-returned without starting the observer.

The Combine sink on `Observable.alarmSoundPlaying` is installed unconditionally, so it fires on every `true → false` transition (sound finishing naturally, manual stop, interruption, snooze). With the feature off, only `alarmStopped()` logged anything, producing a confusing trail of "Alarm stop detected" lines under a category that suggests the volume-button system was involved when it wasn't.

Guard `alarmStopped()` on `isMonitoring`. This makes the start/stop pair symmetric (start is gated on the feature flag; stop is now gated on whether monitoring was engaged) and removes the misleading log noise. The `Invalidating volume observer.` line inside `stopMonitoring()` remains as the single, accurate teardown entry when the feature is on.

No behavior change for users with volume-button snooze enabled.