### PR TITLE
Add App Group capability to Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -183,12 +183,6 @@ platform :ios do
       key_content: "#{FASTLANE_KEY}"
     )
 
-    def find_bundle_id(identifier)
-      bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier)
-    end
-
-    find_bundle_id("com.#{TEAMID}.loopkit.LoopFollow")
-
     match(
       type: "appstore",
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,7 +56,7 @@ platform :ios do
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
       app_identifier: [
         "com.#{TEAMID}.LoopFollow",
-	"com.#{TEAMID}.LoopFollow.LoopFollowLAExtension"
+        "com.#{TEAMID}.LoopFollow.LoopFollowLAExtension"
       ]
     )
 
@@ -139,10 +139,13 @@ platform :ios do
     end
 
     configure_bundle_id("LoopFollow", "com.#{TEAMID}.LoopFollow", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
       Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS
     ])
     
-    configure_bundle_id("LoopFollow Live Activity Extension", "com.#{TEAMID}.LoopFollow.LoopFollowLAExtension", [])
+    configure_bundle_id("LoopFollow Live Activity Extension", "com.#{TEAMID}.LoopFollow.LoopFollowLAExtension", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
+    ])
 
   end
 


### PR DESCRIPTION
With the Live Activity feature, an App Group is required for LoopFollow.

Add this capability to Fastfile so that users just need to configure the App Group when preparing Identifiers.

While updating the Fastfile, remove some unused lines as well.