### PR TITLE
TEST: verify lint CI catches violations (do not merge)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+run-name: Lint (${{ github.head_ref || github.ref_name }})
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  swiftformat:
+    name: SwiftFormat
+    runs-on: ubuntu-latest
+    container: swift:6.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache SwiftFormat build
+        uses: actions/cache@v4
+        with:
+          path: BuildTools/.build
+          key: ${{ runner.os }}-swiftformat-${{ hashFiles('BuildTools/Package.resolved', 'BuildTools/Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftformat-
+
+      - name: SwiftFormat --lint
+        run: |
+          swift run -c release --package-path BuildTools swiftformat . \
+            --lint \
+            --header "LoopFollow\n{file}" \
+            --exclude Pods,Generated,R.generated.swift,fastlane/swift,Dependencies,dexcom-share-client-swift

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/LoopFollow/LintTestThrowaway.swift
+++ b/LoopFollow/LintTestThrowaway.swift
@@ -1,0 +1,11 @@
+// Wrong header on purpose to make swiftformat --lint fail.
+
+import Foundation
+
+struct LintTestThrowaway {
+        let value: Int
+
+        func describe() -> String {
+                return  "value=\(value)"
+        }
+}


### PR DESCRIPTION
Throwaway PR to verify the lint workflow added in #599 actually flags violations.

Adds `LoopFollow/LintTestThrowaway.swift` with intentional issues:
- Wrong file header (not `// LoopFollow\n// LintTestThrowaway.swift`)
- 8-space indentation instead of project standard
- Double space after `return`

Expected: the `Lint / SwiftFormat` check goes red.

**Do not merge.** Will be closed and the branch deleted once #599 is verified.