### PR TITLE
Fix off-by-one in stats period start date and day count

### DIFF
--- a/LoopFollow/Stats/AggregatedStatsView.swift
+++ b/LoopFollow/Stats/AggregatedStatsView.swift
@@ -28,7 +28,7 @@ struct AggregatedStatsView: View {
         let startOfToday = calendar.startOfDay(for: Date())
         let end = calendar.date(byAdding: .second, value: -1, to: startOfToday) ?? Date()
         let endDay = calendar.startOfDay(for: end)
-        let startDay = calendar.date(byAdding: .day, value: -7, to: endDay) ?? endDay
+        let startDay = calendar.date(byAdding: .day, value: -(7 - 1), to: endDay) ?? endDay
         let start = calendar.startOfDay(for: startDay)
         _startDate = State(initialValue: start)
         _endDate = State(initialValue: end)

--- a/LoopFollow/Stats/AggregatedStatsViewModel.swift
+++ b/LoopFollow/Stats/AggregatedStatsViewModel.swift
@@ -39,8 +39,11 @@ class AggregatedStatsViewModel: ObservableObject {
     }
 
     func updatePeriod(_ days: Int, completion: @escaping () -> Void = {}) {
-        let endDate = Date()
-        let startDate = dateTimeUtils.displayCalendar().date(byAdding: .day, value: -days, to: endDate) ?? endDate
+        let calendar = dateTimeUtils.displayCalendar()
+        let startOfToday = calendar.startOfDay(for: Date())
+        let endDate = calendar.date(byAdding: .second, value: -1, to: startOfToday) ?? Date()
+        let endDayStart = calendar.startOfDay(for: endDate)
+        let startDate = calendar.date(byAdding: .day, value: -(days - 1), to: endDayStart) ?? endDayStart
         updateDateRange(start: startDate, end: endDate, completion: completion)
     }
 

--- a/LoopFollow/Stats/DateRangePicker.swift
+++ b/LoopFollow/Stats/DateRangePicker.swift
@@ -31,7 +31,9 @@ struct DateRangePicker: View {
 
     private var dayCount: Int {
         let calendar = dateTimeUtils.displayCalendar()
-        return calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        let startDay = calendar.startOfDay(for: startDate)
+        let endDay = calendar.startOfDay(for: endDate)
+        return (calendar.dateComponents([.day], from: startDay, to: endDay).day ?? 0) + 1
     }
 
     private var lastFullDay: Date {
@@ -241,7 +243,7 @@ struct DateRangePicker: View {
         let calendar = dateTimeUtils.displayCalendar()
         endDate = lastFullDay
         let endDayStart = calendar.startOfDay(for: endDate)
-        let startDayStart = calendar.date(byAdding: .day, value: -days, to: endDayStart) ?? endDayStart
+        let startDayStart = calendar.date(byAdding: .day, value: -(days - 1), to: endDayStart) ?? endDayStart
         startDate = calendar.startOfDay(for: startDayStart)
         showStartDatePicker = false
         showEndDatePicker = false

--- a/LoopFollow/Stats/SimpleStatsViewModel.swift
+++ b/LoopFollow/Stats/SimpleStatsViewModel.swift
@@ -66,7 +66,7 @@ class SimpleStatsViewModel: ObservableObject {
         let smbTotal = smbInPeriod.reduce(0.0) { $0 + $1.value }
         let totalBolusInPeriod = bolusTotal + smbTotal
 
-        let cutoffTime = Date().timeIntervalSince1970 - (Double(dataService.daysToAnalyze) * 24 * 60 * 60)
+        let cutoffTime = dataService.startDate.timeIntervalSince1970
         let allBolusDates = (bolusesInPeriod + smbInPeriod).map { $0.date }.filter { $0 >= cutoffTime }
         let actualDays = calculateActualDaysCovered(dates: allBolusDates, requestedDays: dataService.daysToAnalyze)
 
@@ -93,7 +93,7 @@ class SimpleStatsViewModel: ObservableObject {
 
         let totalCarbsInPeriod = dailyCarbs.values.reduce(0.0, +)
 
-        let daysWithData = max(dailyCarbs.count, 1)
+        let daysWithData = dataService.daysToAnalyze
 
         if daysWithData > 0 {
             avgCarbs = totalCarbsInPeriod / Double(daysWithData)
@@ -295,7 +295,7 @@ class SimpleStatsViewModel: ObservableObject {
         guard !dates.isEmpty else { return requestedDays }
 
         let calendar = dateTimeUtils.displayCalendar()
-        let cutoffTime = Date().timeIntervalSince1970 - (Double(requestedDays) * 24 * 60 * 60)
+        let cutoffTime = dataService.startDate.timeIntervalSince1970
         let filteredDates = dates.filter { $0 >= cutoffTime }
 
         var uniqueDays = Set<Date>()

--- a/LoopFollow/Stats/StatsDataService.swift
+++ b/LoopFollow/Stats/StatsDataService.swift
@@ -32,9 +32,11 @@ class StatsDataService {
     func updateDateRange(start: Date, end: Date) {
         startDate = start
         endDate = end
-        // Also update daysToAnalyze for compatibility with existing code
-        let daysBetween = dateTimeUtils.displayCalendar().dateComponents([.day], from: start, to: end).day ?? 14
-        daysToAnalyze = max(daysBetween, 1)
+        let calendar = dateTimeUtils.displayCalendar()
+        let startDay = calendar.startOfDay(for: start)
+        let endDay = calendar.startOfDay(for: end)
+        let daysBetween = calendar.dateComponents([.day], from: startDay, to: endDay).day ?? 13
+        daysToAnalyze = daysBetween + 1
     }
 
     func ensureDataAvailable(onProgress: @escaping () -> Void, completion: @escaping () -> Void) {


### PR DESCRIPTION
The stats model has a systematic off-by-one error in how the analysis window start date is computed, causing the selected period to span one extra day and all per-day averages to be divided by the wrong count.

### Problem

When a quick-select preset (7d, 14d, 30d) is chosen, or when the stats view opens, the end date is correctly set to the end of yesterday (the last complete day). However, the start date is computed by subtracting `N` calendar days from the start of the end day rather than `N - 1`, producing a window of `N + 1` days.

For example, selecting "7d" with yesterday = Apr 25 produces:
- start = Apr 25 − 7 days = **Apr 18**
- end = Apr 25 23:59:59
- Actual range: **8 days** (Apr 18–25)

The day count label compounds the issue by using an exclusive date diff (`dateComponents([.day], from: start, to: end)`), so it displays **"7 days"** for an 8-day window — the label and the actual range disagree in opposite directions.

`StatsDataService.updateDateRange()` then computes `daysToAnalyze` from the same exclusive diff, storing 7 for an 8-day range. This value is used as the denominator in per-day averages, overstating them.

**Secondary inconsistencies:**
- The bolus cutoff in `SimpleStatsViewModel` re-derives its own anchor from `Date() - requestedDays * 86400` instead of reading `dataService.startDate`, so it can diverge from the resolved period.
- `avgCarbs` uses `dailyCarbs.count` (days with at least one entry) as the denominator rather than the full period length, inflating the average on carb-free days.
- `calculateActualDaysCovered()` has the same `Date()`-anchored re-derivation.

### Fix

- Start date uses `endDay - (N - 1)` so a "7d" preset spans exactly Apr 19–Apr 25 (7 days inclusive).
- `daysToAnalyze` is computed as `daysBetween + 1` on day-start boundaries.
- Day count label adds 1 to the exclusive diff so it matches the actual window.
- Bolus cutoff and `calculateActualDaysCovered` read `dataService.startDate` directly.
- `avgCarbs` denominator uses `dataService.daysToAnalyze`.
- `AggregatedStatsView.init()` had a separate hardcoded `value: -7` offset that was also corrected to `-(7 - 1)`.

### Time zone note

All date arithmetic goes through `dateTimeUtils.displayCalendar()`, which respects the user's configured graph time zone or the device time zone. `startOfDay(for:)` and `date(byAdding: .day)` use calendar days rather than fixed 86 400-second intervals, so DST transitions are handled correctly.