### PR TITLE
Fix duplicate chevron on Import/Export Settings row

### DIFF
--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -71,13 +71,8 @@ struct RemoteSettingsView: View {
                         Image(systemName: "square.and.arrow.down")
                             .foregroundColor(.blue)
                         Text("Import/Export Settings")
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .foregroundColor(.secondary)
-                            .font(.caption)
                     }
                 }
-                .buttonStyle(.plain)
             }
 
             // MARK: - Meal Section (for TRC only)


### PR DESCRIPTION
## Summary
The Import/Export Settings row in Remote Settings used a `NavigationLink` (which renders its own chevron) and also added a manual `chevron.right` image, producing a doubled `>>`. Removed the manual chevron so the row matches the rest of the app.