### PR TITLE
Chore/update to fastlane 2.233.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
-gem "fastlane", "2.232.2"
+gem "fastlane", "2.233.1"
+gem "json", ">=2.19.2"
+gem "addressable", ">=2.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.232.2)
+    fastlane (2.233.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -92,7 +92,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       faraday_middleware (~> 1.0)
       fastimage (>= 2.1.0, < 3.0.0)
-      fastlane-sirp (>= 1.0.0)
+      fastlane-sirp (>= 1.1.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
@@ -122,8 +122,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-sirp (1.0.0)
-      sysrandom (~> 1.0)
+    fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.54.0)
       google-apis-core (>= 0.11.0, < 2.a)
@@ -203,7 +202,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -232,7 +230,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.2)
+  addressable (>= 2.9.0)
+  fastlane (= 2.233.1)
+  json (>= 2.19.2)
 
 BUNDLED WITH
   4.0.6


### PR DESCRIPTION
## Purpose

Use the most recent version of fastlane, 2.233.1, and address dependabot security issues with the Gemfile.lock file.

Mirrors LoopKit/LoopWorkspace#437.

## Method

### Update to fastlane 2.233.1

1. Modify `Gemfile` for fastlane 2.233.1
2. In Terminal, run `bundle install`
3. Commit the modified `Gemfile` and `Gemfile.lock`

### Address security issues

1. Modify `Gemfile` to add `gem "json", ">=2.19.2"` and `gem "addressable", ">=2.9.0"`
2. In Terminal, run `bundle install`
3. Commit the modified `Gemfile` and `Gemfile.lock`