### PR TITLE
Recognize Atlas DASH pod in Omnipod heartbeat scan

### DIFF
--- a/LoopFollow/BackgroundRefresh/BackgroundRefreshType.swift
+++ b/LoopFollow/BackgroundRefresh/BackgroundRefreshType.swift
@@ -61,8 +61,10 @@ enum BackgroundRefreshType: String, Codable, CaseIterable {
 
         case .omnipodDash:
             if let name = device.name {
-                // actual DASH or rPi DASH simulator
-                return name == "TWI BOARD" || name == " :: Fake POD ::"
+                // "TWI BOARD": original DASH pod
+                // "InPlay BLE": newer Atlas DASH pod
+                // " :: Fake POD ::": rPi DASH simulator
+                return name == "TWI BOARD" || name == "InPlay BLE" || name == " :: Fake POD ::"
             }
             return false
 


### PR DESCRIPTION
## Summary
- Fixes #630: Atlas (newer Insulet) DASH pods were never offered by the Bluetooth scan when *Background Refresh → Omnipod Dash* was selected.
- Atlas pods advertise the BLE peripheral name `"InPlay BLE"` instead of `"TWI BOARD"`, but expose the same OmniBLE service (`1A7E4024-…`) and data characteristic (`1A7E2442-…`), so the existing `OmnipodDashHeartbeatBluetoothTransmitter` works as-is — only the scanner's name matcher needed to accept the new name.