### PR TITLE
Fix Live Activity: guard showRenewalOverlay on iOS 17.2+, fix LA tap …

### DIFF
--- a/LoopFollow/LiveActivity/LiveActivityManager.swift
+++ b/LoopFollow/LiveActivity/LiveActivityManager.swift
@@ -349,6 +349,11 @@ final class LiveActivityManager {
 
     @objc private func handleBackgroundAudioFailed() {
         guard Storage.shared.laEnabled.value, current != nil else { return }
+        if #available(iOS 17.2, *) {
+            // Push-to-start handles LA renewal on iOS 17.2+ without requiring the
+            // user to foreground the app, so no renewal overlay is needed.
+            return
+        }
         // The background audio session has permanently failed — the app will lose its
         // background keep-alive. Immediately push the renewal overlay so the user sees
         // "Tap to update" on the lock screen and knows to foreground the app.

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -762,6 +762,15 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             }
         }
 
+        // Fallback: derive the expected index from the stored snoozer position.
+        // When snoozer is in the menu (.menu), tabIndex == 4 — the Menu tab.
+        // This is better than falling back to Home (0) because the user can at
+        // least reach the snoozer from the menu tab in one tap.
+        let position = Storage.shared.snoozerPosition.value.normalized
+        if let tabIndex = position.tabIndex, tabIndex < viewControllers.count {
+            return tabIndex
+        }
+
         return nil
     }
 


### PR DESCRIPTION
- Guard showRenewalOverlay behind iOS 17.2: push-to-start handles LA renewal on 17.2+ via APNs so the "Tap to update" overlay is unnecessary there
- Add fallback in getSnoozerTabIndex() for when the snoozer lives in the menu tab rather than as a direct tab, so the LA lock-screen tap lands at the menu instead of silently falling through to home
