### PR TITLE
Move release flow to PR-based and add CODEOWNERS for branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for LoopFollow.
+# Owners listed here are automatically requested for review on PRs and,
+# when "Require review from Code Owners" is enabled in branch protection,
+# their approval is required before a PR can be merged.
+
+* @marionbarker @bjorkert @codebymini

--- a/.github/workflows/auto_version_dev.yml
+++ b/.github/workflows/auto_version_dev.yml
@@ -43,13 +43,32 @@ jobs:
         uses: actions/checkout@v5
         with:
             token: ${{ secrets.LOOPFOLLOW_TOKEN_AUTOBUMP }}
+            fetch-depth: 0
+
+      - name: Skip if Config.xcconfig was changed in this push
+        id: check
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "No previous SHA on this push; not skipping."
+            exit 0
+          fi
+          if git diff "$BEFORE..HEAD" -- Config.xcconfig | grep -qE '^\+LOOP_FOLLOW_MARKETING_VERSION'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "LOOP_FOLLOW_MARKETING_VERSION was set in this push (likely a release sync); skipping auto-bump."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Git
+        if: steps.check.outputs.skip != 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump dev version number in Config.xcconfig
+        if: steps.check.outputs.skip != 'true'
         run: |
           FILE=Config.xcconfig
 
@@ -85,6 +104,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Commit and push changes
+        if: steps.check.outputs.skip != 'true'
         run: |
           git add Config.xcconfig
           git commit -m "CI: Bump dev version to $NEW_VERSION [skip ci]"

--- a/.github/workflows/auto_version_dev.yml
+++ b/.github/workflows/auto_version_dev.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   bump-version:
-    if: github.repository_owner == 'loopandlearn'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tag_on_main.yml
+++ b/.github/workflows/tag_on_main.yml
@@ -1,0 +1,68 @@
+# -----------------------------------------------------------------------------
+# Workflow: Tag release on push to main
+#
+# Description:
+# Creates an annotated git tag whenever main advances to a release version
+# (X.Y.0). The version is read from LOOP_FOLLOW_MARKETING_VERSION in
+# Config.xcconfig and the tag name is `v<version>`.
+#
+# Triggered by: any push to main (release PR merge).
+# Skips if: the version on main is not X.Y.0 (e.g. a hotfix that didn't bump
+# minor/major), or if the tag already exists.
+# -----------------------------------------------------------------------------
+
+name: Tag release on main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: github.repository_owner == 'loopandlearn'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Config.xcconfig
+        id: version
+        run: |
+          VERSION=$(grep -E "^LOOP_FOLLOW_MARKETING_VERSION[[:space:]]*=" Config.xcconfig | awk '{print $3}')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not find LOOP_FOLLOW_MARKETING_VERSION in Config.xcconfig"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Found version: $VERSION"
+
+      - name: Skip non-release versions (only X.Y.0 is tagged)
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION is not a release version (X.Y.0); skipping tag."
+          fi
+
+      - name: Create and push tag if missing
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; skipping."
+          else
+            git tag -a "$TAG" -m "$TAG"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+          fi

--- a/.github/workflows/tag_on_main.yml
+++ b/.github/workflows/tag_on_main.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   tag:
-    if: github.repository_owner == 'loopandlearn'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/warn_main_pr.yml
+++ b/.github/workflows/warn_main_pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   warn:
-    if: github.repository_owner == 'loopandlearn'
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/release.sh
+++ b/release.sh
@@ -117,12 +117,20 @@ git diff -M --binary "$MAIN_BRANCH" "$RELEASE_BRANCH"  \
   > "$PATCH_FILE"
 
 cd ..
-update_follower "$SECOND_DIR"
-update_follower "$THIRD_DIR"
+if [ -n "${SKIP_SISTER_REPOS:-}" ]; then
+  echo "⏭️  Skipping sister repo updates (SKIP_SISTER_REPOS is set)"
+else
+  update_follower "$SECOND_DIR"
+  update_follower "$THIRD_DIR"
+fi
 
 # ---------- GitHub Actions Test ---------
-echo; 
-echo "💻  Test GitHub Build Actions for all three repositories and then continue."; 
+echo;
+if [ -n "${SKIP_SISTER_REPOS:-}" ]; then
+  echo "💻  Test GitHub Build Actions for the primary repository and then continue.";
+else
+  echo "💻  Test GitHub Build Actions for all three repositories and then continue.";
+fi
 pause
 
 # --- return to primary path

--- a/release.sh
+++ b/release.sh
@@ -37,15 +37,27 @@ update_follower () {
   echo_run git fetch
   echo_run git pull
 
-  # 2 · Apply the patch
-  if ! git apply --whitespace=nowarn "$PATCH_FILE"; then
+  # 2 · Build --exclude args for files in the patch that don't exist here.
+  #     Sister repos are intentionally stripped of dev-only files
+  #     (release.sh, auto_version_dev.yml, lint.yml, warn_main_pr.yml, …),
+  #     so any patch hunk targeting one of those would otherwise abort.
+  local apply_args=(--whitespace=nowarn)
+  while IFS= read -r missing; do
+    [ -z "$missing" ] && continue
+    apply_args+=("--exclude=$missing")
+    echo "ℹ️  Excluding $missing (not present in $DIR)"
+  done < <(git apply --check "$PATCH_FILE" 2>&1 \
+             | sed -nE 's/^error: (.+): No such file or directory$/\1/p')
+
+  # 3 · Apply the patch (with any excludes)
+  if ! git apply "${apply_args[@]}" "$PATCH_FILE"; then
     echo "‼️  Some changes could not be applied, so no changes were made."
-    echo "The command used was: git apply --whitespace=nowarn $PATCH_FILE"
+    echo "The command used was: git apply ${apply_args[*]} $PATCH_FILE"
     echo; echo "Use a different terminal to fix and apply the patch before continuing"
     pause
   fi
 
-  # 3 · Pause if any conflict markers remain
+  # 4 · Pause if any conflict markers remain
   if git ls-files -u | grep -q .; then
     echo "⚠️  Conflicts detected."
     echo "    If Fastfile or build_LoopFollow.yml were modified, these are expected."
@@ -53,7 +65,7 @@ update_follower () {
     pause
   fi
 
-  # 4 · Single commit capturing all staged changes
+  # 5 · Single commit capturing all staged changes
   git add -u
   git add $(git ls-files --others --exclude-standard) 2>/dev/null || true
   git commit -m "transfer v${new_ver} updates from LF to ${DIR}"

--- a/release.sh
+++ b/release.sh
@@ -117,20 +117,12 @@ git diff -M --binary "$MAIN_BRANCH" "$RELEASE_BRANCH"  \
   > "$PATCH_FILE"
 
 cd ..
-if [ -n "${SKIP_SISTER_REPOS:-}" ]; then
-  echo "⏭️  Skipping sister repo updates (SKIP_SISTER_REPOS is set)"
-else
-  update_follower "$SECOND_DIR"
-  update_follower "$THIRD_DIR"
-fi
+update_follower "$SECOND_DIR"
+update_follower "$THIRD_DIR"
 
 # ---------- GitHub Actions Test ---------
-echo;
-if [ -n "${SKIP_SISTER_REPOS:-}" ]; then
-  echo "💻  Test GitHub Build Actions for the primary repository and then continue.";
-else
-  echo "💻  Test GitHub Build Actions for all three repositories and then continue.";
-fi
+echo; 
+echo "💻  Test GitHub Build Actions for all three repositories and then continue."; 
 pause
 
 # --- return to primary path

--- a/release.sh
+++ b/release.sh
@@ -24,11 +24,6 @@ echo_run()  { echo "+ $*"; "$@"; }
 push_cmds=()
 queue_push() { push_cmds+=("git -C \"$(pwd)\" $*"); echo "+ [queued] (in $(pwd)) git $*"; }
 
-queue_push_tag () {
-  local tag="$1"
-  queue_push push origin "refs/tags/$tag"
-}
-
 update_follower () {
   local DIR="$1"
   echo; echo "🔄  Updating $DIR …"
@@ -97,31 +92,29 @@ esac
 
 echo "🔢  Bumping version: $old_ver  →  $new_ver"
 
-# --- switch to dev branch ----
+# --- switch to dev so the release branch is cut from latest dev ----
 echo_run git switch "$DEV_BRANCH"
 echo_run git fetch
 echo_run git pull
 
-# --- update version number ----
+# --- create release branch from dev's tip ----
+RELEASE_BRANCH="release/v${new_ver}"
+echo_run git switch -c "$RELEASE_BRANCH"
+
+# --- bump version on the release branch ----
 sed -i '' "s/${MARKETING_KEY}[[:space:]]*=.*/${MARKETING_KEY} = ${new_ver}/" "$VERSION_FILE"
 echo_run git diff "$VERSION_FILE"; pause
 echo_run git commit -m "update version to ${new_ver} [skip ci]" "$VERSION_FILE"
 
-echo "💻  Build & test dev branch now."; pause
-queue_push push origin "$DEV_BRANCH"
+echo "💻  Build & test release branch now."; pause
+queue_push push origin "$RELEASE_BRANCH"
 
-# --- create a patch  ---------------------------
+# --- create a patch from main..release branch (includes the bump) -----
 mkdir -p "$PATCH_DIR"
 PATCH_FILE="${PATCH_DIR}/LF_diff_${old_ver}_to_${new_ver}.patch"
 
-git diff -M --binary "$MAIN_BRANCH" "$DEV_BRANCH"  \
+git diff -M --binary "$MAIN_BRANCH" "$RELEASE_BRANCH"  \
   > "$PATCH_FILE"
-
-# --- merge dev into main for new release
-echo_run git switch "$MAIN_BRANCH"
-echo_run git merge "$DEV_BRANCH"
-echo "💻  Build & test main branch now."; pause
-queue_push push origin "$MAIN_BRANCH"
 
 cd ..
 update_follower "$SECOND_DIR"
@@ -136,24 +129,39 @@ pause
 cd ${PRIMARY_ABS_PATH}
 
 # ---------- push queue ----------
-echo; echo "🚀  Ready to tag and push changes upstream."
+echo; echo "🚀  Ready to push changes upstream and open the release PR."
 echo_run git log --oneline -2
-
-read -rp "▶▶  Ready to tag? (y/n): " confirm
-if [[ $confirm =~ ^[Yy]$ ]]; then
-  git tag -a "v${new_ver}" -m "v${new_ver}"
-  queue_push_tag "v${new_ver}"
-  echo_run git log --oneline -2
-else
-  echo "🚫  tag skipped, can add later"
-fi
 
 read -rp "▶▶  Push everything now? (y/n): " confirm
 if [[ $confirm =~ ^[Yy]$ ]]; then
   for cmd in "${push_cmds[@]}"; do echo "+ $cmd"; bash -c "$cmd"; done
   echo "🎉  All pushes completed."
-  echo; echo "🎉  All repos updated to v${new_ver} (local)."
-  echo "👉  Remember to create a GitHub release for tag v${new_ver}."
+
+  echo; echo "📝  Opening sync PR ${RELEASE_BRANCH} → ${DEV_BRANCH} …"
+  gh pr create \
+    --base "$DEV_BRANCH" \
+    --head "$RELEASE_BRANCH" \
+    --title "Sync v${new_ver} version bump to dev" \
+    --body "Syncs the v${new_ver} version bump from the release branch back to \`dev\` so subsequent auto-bumps on \`dev\` continue from the released minor.
+
+\`auto_version_dev\` detects that \`Config.xcconfig\` was changed in this push and skips re-bumping.
+
+⚠️ **Use rebase-merge** (not squash or merge-commit) so \`dev\` and \`main\` end up at the same commit SHA after the release."
+
+  echo; echo "📝  Opening release PR ${RELEASE_BRANCH} → ${MAIN_BRANCH} …"
+  gh pr create \
+    --base "$MAIN_BRANCH" \
+    --head "$RELEASE_BRANCH" \
+    --title "Release v${new_ver}" \
+    --body "Release v${new_ver}.
+
+Merging this PR triggers the tagging workflow, which creates tag \`v${new_ver}\` from \`LOOP_FOLLOW_MARKETING_VERSION\` in \`Config.xcconfig\`.
+
+⚠️ **Use rebase-merge** (not squash or merge-commit) so \`dev\` and \`main\` end up at the same commit SHA after the release."
+
+  echo; echo "🎉  All repos updated to v${new_ver} (local). Release PRs opened (sync → dev, release → main)."
+  echo "👉  Review and merge both PRs — the tag will be created automatically by .github/workflows/tag_on_main.yml."
+  echo "👉  Remember to create a GitHub release for tag v${new_ver} after the tag exists."
 else
   echo "🚫  Pushes skipped.  Run manually if needed:"; printf '   %s\n' "${push_cmds[@]}"
   echo "🚫  Release not completed, pushes to GitHub were skipped"

--- a/release.sh
+++ b/release.sh
@@ -37,27 +37,15 @@ update_follower () {
   echo_run git fetch
   echo_run git pull
 
-  # 2 · Build --exclude args for files in the patch that don't exist here.
-  #     Sister repos are intentionally stripped of dev-only files
-  #     (release.sh, auto_version_dev.yml, lint.yml, warn_main_pr.yml, …),
-  #     so any patch hunk targeting one of those would otherwise abort.
-  local apply_args=(--whitespace=nowarn)
-  while IFS= read -r missing; do
-    [ -z "$missing" ] && continue
-    apply_args+=("--exclude=$missing")
-    echo "ℹ️  Excluding $missing (not present in $DIR)"
-  done < <(git apply --check "$PATCH_FILE" 2>&1 \
-             | sed -nE 's/^error: (.+): No such file or directory$/\1/p')
-
-  # 3 · Apply the patch (with any excludes)
-  if ! git apply "${apply_args[@]}" "$PATCH_FILE"; then
+  # 2 · Apply the patch
+  if ! git apply --whitespace=nowarn "$PATCH_FILE"; then
     echo "‼️  Some changes could not be applied, so no changes were made."
-    echo "The command used was: git apply ${apply_args[*]} $PATCH_FILE"
+    echo "The command used was: git apply --whitespace=nowarn $PATCH_FILE"
     echo; echo "Use a different terminal to fix and apply the patch before continuing"
     pause
   fi
 
-  # 4 · Pause if any conflict markers remain
+  # 3 · Pause if any conflict markers remain
   if git ls-files -u | grep -q .; then
     echo "⚠️  Conflicts detected."
     echo "    If Fastfile or build_LoopFollow.yml were modified, these are expected."
@@ -65,7 +53,7 @@ update_follower () {
     pause
   fi
 
-  # 5 · Single commit capturing all staged changes
+  # 4 · Single commit capturing all staged changes
   git add -u
   git add $(git ls-files --others --exclude-standard) 2>/dev/null || true
   git commit -m "transfer v${new_ver} updates from LF to ${DIR}"


### PR DESCRIPTION
## Summary

Prepares the repo for branch protection rulesets on `dev` and `main` by:

- Adding `.github/CODEOWNERS`
- Switching the release flow from "merge dev → main locally + push" to a PR-based flow with two PRs (sync to dev, release to main)
- Moving tag creation out of `release.sh` into a workflow that fires on push to `main`
- Adding a guard to `auto_version_dev` so it doesn't double-bump after a release sync-PR is merged into `dev`

No rules are activated by this PR — those are flipped manually in repo Settings → Rules after this lands. See "Rollout" below.

## Changes

### `.github/CODEOWNERS`
New file. Single rule covering the whole repo:

```
* @marionbarker @bjorkert @codebymini
```

Used by the future `dev`/`main` rulesets to require an approval from a code owner before merging.

### `.github/workflows/tag_on_main.yml`
New workflow. Triggers on push to `main`, reads `LOOP_FOLLOW_MARKETING_VERSION` from `Config.xcconfig`, and creates `v<version>` if:
- the version matches `X.Y.0` (release versions only, not patch numbers)
- the tag doesn't already exist (idempotent — safe to re-run)

This replaces the manual `git tag -a` step previously done in `release.sh`.

### `.github/workflows/auto_version_dev.yml`
Adds a "skip if `Config.xcconfig` was changed in this push" guard before the bump step. Without this, merging the release sync-PR into `dev` would immediately re-bump the version (e.g. 3.0.0 → 3.0.1). The guard uses `git diff <before>..HEAD` so it works regardless of merge strategy (merge commit / squash / rebase).

### `release.sh`
- Cuts a `release/v<ver>` branch from `dev` and commits the version bump there (instead of bumping `dev` directly with a push)
- No more local `git switch main && git merge dev && git push main` — that becomes a PR
- Tag creation removed (handled by the new workflow)
- Opens two PRs at the end:
  - `release/v<ver> → dev` to sync the version bump back
  - `release/v<ver> → main` for the actual release
- Sister-repo handling (`LoopFollow_Second`, `LoopFollow_Third`) is unchanged

## New release flow

1. Run `release.sh`, pick minor/major
2. Script creates `release/vX.Y.0` from `dev`, commits the version bump there
3. Script pushes the release branch and the sister-repo updates
4. Script opens **two PRs**: sync → `dev`, release → `main`
5. Review and merge both (any order)
6. `tag_on_main.yml` creates the `vX.Y.0` tag automatically on the main merge
7. Create the GitHub Release manually for the new tag (unchanged from today)

## Merge strategy

Two PR types in this repo, two different conventions:

- **Regular PRs to `dev` (contributor PRs):** squash and merge — keeps `dev`'s history clean. This is the repo default.
- **The two release PRs (sync → `dev` and release → `main`):** rebase and merge.

The release PRs need rebase-merge for one cosmetic reason: it's the only strategy that lets `dev` and `main` end up at the *same commit SHA* after the release. With squash or merge-commit, the file contents are identical on both branches but the commit objects have different SHAs (different parents). Rebase-merge fast-forwards both branches to the release branch's tip, so the tag commit is reachable from both.

Tree contents are identical either way, so picking the wrong strategy doesn't break anything functionally — but the SHA mismatch makes \`git log dev\` and \`git log main\` diverge cosmetically right after a release.

The two release PRs opened by `release.sh` mention this requirement in their bodies as a reminder.

## Rollout

Rulesets are not activated by this PR. Sequence:

1. **Merge this PR to `dev`** (last merge that goes through the current honor system; squash-merge as usual)
2. **Activate `dev` ruleset** in repo Settings → Rules:
   - Require pull request before merging
   - Require 1 approval (GitHub already blocks self-approval)
   - Require review from Code Owners
   - Dismiss stale approvals on new commits
   - **Bypass list: `LOOPFOLLOW_TOKEN_AUTOBUMP`** — required, otherwise `auto_version_dev` can't push the patch bump back to `dev`
3. **Next release** — run the new `release.sh`. Both PRs merge to `dev` and `main` (rebase-merge), putting `CODEOWNERS` and `tag_on_main.yml` onto `main`
4. **Activate `main` ruleset** (now that `CODEOWNERS` exists on `main`):
   - Require pull request before merging
   - Require 1 approval, must come from a Code Owner
   - Dismiss stale approvals on new commits
   - No bypass list needed

Between steps 2 and 4, `main` is still under the existing honor system — same as today, just for a short window until the next release.

## Notes

- After this lands, pull `dev` before the next release so the new `release.sh` is in your local checkout
- The new flow opens two PRs per release instead of one — both need to be merged, **both with rebase-merge**, for the release to be complete with matching SHAs
- If you ever need to push to `dev` outside the autobumper (e.g. an emergency hotfix), you'll be blocked by the ruleset once it's active; do it through a PR