### PR TITLE
Bug fix: carb dots overlapping SMB dots on the chart

### DIFF
--- a/LoopFollow/Controllers/Nightscout/Treatments/Carbs.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Carbs.swift
@@ -10,6 +10,7 @@ extension MainViewController {
         carbData.removeAll()
         var lastFoundIndex = 0
         var lastFoundBolus = 0
+        var lastFoundSmb = 0
 
         for currentEntry in entries.reversed() {
             var carbDate: String
@@ -35,7 +36,10 @@ extension MainViewController {
                 let bolusTime = findNearestBolusbyTime(timeWithin: 300, needle: dateTimeStamp, haystack: bolusData, startingIndex: lastFoundBolus)
                 lastFoundBolus = bolusTime.foundIndex
 
-                offset = bolusTime.offset ? 70 : 20
+                let smbTime = findNearestBolusbyTime(timeWithin: 300, needle: dateTimeStamp, haystack: smbData, startingIndex: lastFoundSmb)
+                lastFoundSmb = smbTime.foundIndex
+
+                offset = (bolusTime.offset || smbTime.offset) ? 70 : 20
             }
 
             if dateTimeStamp < (dateTimeUtils.getNowTimeIntervalUTC() + (3600 * Storage.shared.predictionToLoad.value)) {


### PR DESCRIPTION
- Restores pre-PR #305 behavior; no other dot positioning changes
- Carb dots entered alongside an SMB were rendering at the same Y position as the SMB triangle, visually overlapping
- The carb-vs-bolus collision logic was supposed to lift the carb dot above the bolus to BG+70, but only checked for Boluses (not SMB)
- Regression comes from PR #305 (SMB display differentiated from boluses), which split SMBs into their own smbData array. - After the split, findNearestBolusbyTime in processNSCarbs no longer saw SMBs as "nearby treatments," so carb-near-SMB fell through to the default BG+20 offset: the same Y as the SMB itself.
- processNSCarbs now also looks up smbData.
- A carb within 300s of either a bolus OR SMB lifts to BG+70; otherwise BG+20.