### PR TITLE
Cap prediction cone to shortest predBG array length

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -1991,9 +1991,11 @@ extension MainViewController {
 
             var coneData = [ConeChartDataEntry]()
             if !allArrays.isEmpty {
-                let maxLength = min(allArrays.map { $0.count }.max()!, toLoad + 1)
+                // Cap at the shortest predBG array length so every cone point uses
+                // the same set of contributing arrays. Matches Trio's ForecastSetup.
+                let coneLength = min(allArrays.map { $0.count }.min()!, toLoad + 1)
                 var t = predictionStart
-                for i in 0 ..< maxLength {
+                for i in 0 ..< coneLength {
                     var valuesAtIndex = [Double]()
                     for arr in allArrays where i < arr.count {
                         valuesAtIndex.append(arr[i])


### PR DESCRIPTION
Fixes #637.

## Summary

`updateOpenAPSPredictionDisplay()` capped the cone at the longest predBG
array, so at indices past shorter arrays the cone deformed -- the band
narrowed or shifted as contributing arrays dropped out one by one.

This caps at the shortest array length instead. Every cone point is
computed from the same set of contributing arrays; the band ends cleanly
when the first array runs out.

Compared against `nightscout/Trio` `Trio/Sources/Modules/Home/HomeStateModel+Setup/ForecastSetup.swift`:

```swift
minCount = max(12, allForecastValues.map(\.count).min() ?? 0)
let localMinCount = minCount
// ...
let minForecast = (0 ..< localMinCount).map { ... }
let maxForecast = (0 ..< localMinCount).map { ... }
```

Trio iterates `0 ..< localMinCount` -- every cone point uses values from
all contributing arrays. This PR brings LoopFollow to the same shape.

Did not adopt Trio's `max(12, ...)` floor; open to adding it if preferred.

## User-visible behavior

- For users whose shortest predBG array is materially shorter than the
  longest, the cone will visibly end earlier than before. The
  previously-rendered tail was narrowing/shifting with no real meaning.
- `topPredictionBG` (graph y-axis upper bound) is updated inside the
  loop. With the shorter loop, the upper bound may sit slightly tighter
  for some sessions. No data is cropped (the loop's output is what gets
  drawn); just less empty headroom in mixed-length-array cases.
