### PR TITLE
Suppress silent passive notifications in willPresent handler

### DIFF
--- a/LoopFollow/Application/AppDelegate.swift
+++ b/LoopFollow/Application/AppDelegate.swift
@@ -231,12 +231,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void)
     {
-        // Log the notification
-        let userInfo = notification.request.content.userInfo
-        let userInfoKeys = userInfo.keys.compactMap { $0 as? String }.sorted()
-        LogManager.shared.log(category: .general, message: "Will present notification: keys=\(userInfoKeys)")
+        let content = notification.request.content
+        let userInfoKeys = content.userInfo.keys.compactMap { $0 as? String }.sorted()
+        LogManager.shared.log(
+            category: .general,
+            message: "Will present notification: keys=\(userInfoKeys), interruption=\(content.interruptionLevel.rawValue), title=\(content.title.isEmpty ? "empty" : "set"), body=\(content.body.isEmpty ? "empty" : "set")"
+        )
 
-        // Show the notification even when app is in foreground
+        // Suppress notifications iOS routes here that we never intended to surface:
+        // the Live Activity push-to-start uses interruption-level: passive with empty
+        // title/body and must not produce a banner or sound when LF is foregrounded.
+        if content.interruptionLevel == .passive || (content.title.isEmpty && content.body.isEmpty) {
+            completionHandler([])
+            return
+        }
+
         completionHandler([.banner, .sound, .badge])
     }
 }


### PR DESCRIPTION
## Summary

`UNUserNotificationCenterDelegate.willPresent` in `AppDelegate` returned
`[.banner, .sound, .badge]` unconditionally, so any notification iOS
routed through the handler while the app was foregrounded produced
sound — including the Live Activity push-to-start payload, which is
intentionally silent (`interruption-level: passive`, empty title/body).
6.1.0 users reported the silent renewal triggering an audible banner.

## Change

- Return `[]` for passive notifications and for notifications with
  empty title/body.
- The four intentional alerts (`scheduleRenewalFailed…`,
  `scheduleApnsCredentialsMissing…`, `schedulePushToStartTokenMissing…`,
  alarms) all use non-empty title/body and the default `.active`
  interruption level, so they continue to surface as banners.
- Expanded the `willPresent` log line with `interruptionLevel` and
  whether title/body are empty so future reports can confirm whether iOS
  is routing a given payload through this handler.

Replaces #638 (split into three independently reviewable PRs).