### PR TITLE
ITMS-91061 - privacy manifest for Charts framework

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,4 +33,36 @@ post_install do |installer|
       File.write(transformer, code.sub(original, patched))
     end
   end
+
+  # Inject a privacy manifest into the Charts framework (ITMS-91061).
+  # Charts 4.1.0 ships no PrivacyInfo.xcprivacy; it collects no data, performs
+  # no tracking, and uses no required-reason APIs, so this is a negative
+  # declaration. Re-applied here because `pod install` regenerates the project.
+  charts_manifest = <<~XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+    \t<key>NSPrivacyTracking</key>
+    \t<false/>
+    \t<key>NSPrivacyTrackingDomains</key>
+    \t<array/>
+    \t<key>NSPrivacyCollectedDataTypes</key>
+    \t<array/>
+    \t<key>NSPrivacyAccessedAPITypes</key>
+    \t<array/>
+    </dict>
+    </plist>
+  XML
+
+  manifest_path = installer.sandbox.root + 'Charts/PrivacyInfo.xcprivacy'
+  File.write(manifest_path, charts_manifest)
+
+  charts_target = installer.pods_project.targets.find { |t| t.name == 'Charts' }
+  if charts_target
+    file_ref = installer.pods_project.new_file(manifest_path.to_s)
+    already_added = charts_target.resources_build_phase.files_references.include?(file_ref)
+    charts_target.resources_build_phase.add_file_reference(file_ref) unless already_added
+    installer.pods_project.save
+  end
 end

--- a/Pods/Charts/PrivacyInfo.xcprivacy
+++ b/Pods/Charts/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BEEF11110000000000000002 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BEEF11110000000000000001 /* PrivacyInfo.xcprivacy */; };
 		0031CEAD857A1BA158C0D2BE1870A438 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB10D8BF2F0C2E9B18C2130751D75984 /* Animator.swift */; };
 		00351B69906B07C1950B97C40F65FABE /* RadarChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51F17D0D2858BA593E783811A2CF7E6 /* RadarChartData.swift */; };
 		00E171A24B8B214FDC447BED6BB62C31 /* BarLineScatterCandleBubbleChartDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B90B940BBEE17272D0FA9602CB3F1E1 /* BarLineScatterCandleBubbleChartDataSet.swift */; };
@@ -220,6 +221,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BEEF11110000000000000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0047677618FCD329E548FDDC0454A8AC /* LineChartView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LineChartView.swift; path = Source/Charts/Charts/LineChartView.swift; sourceTree = "<group>"; };
 		0055C3AB0AE0067E0AF50DA569843398 /* BarChartView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BarChartView.swift; path = Source/Charts/Charts/BarChartView.swift; sourceTree = "<group>"; };
 		0187F74F0F2E1ADE4F205C203F88DE85 /* RadarChartView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadarChartView.swift; path = Source/Charts/Charts/RadarChartView.swift; sourceTree = "<group>"; };
@@ -759,6 +761,7 @@
 		E5EBEB4E3DD769CF77FBA0FB4DD5A204 /* Charts */ = {
 			isa = PBXGroup;
 			children = (
+				BEEF11110000000000000001 /* PrivacyInfo.xcprivacy */,
 				64FE9452040001E25B5A3EB8D58108DB /* Core */,
 				AEDEF3B82F3D135001FB2D1778DAD53F /* Support Files */,
 			);
@@ -944,6 +947,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEEF11110000000000000002 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
App Store submission was rejected with ITMS-91061: Missing privacy manifest
for Frameworks/Charts.framework. The bundled Charts pod predates
Apple's privacy-manifest requirement and ships no PrivacyInfo.xcprivacy, so
the built framework lacks one.

This adds a privacy manifest to the Charts framework.

TF error:
ITMS-91061: Missing privacy manifest - Your app includes “Frameworks/Charts.framework/Charts”, which includes Charts, an SDK that was identified in the documentation as a commonly used third-party SDK. If a new app includes a commonly used third-party SDK, or an app update adds a new commonly used third-party SDK, the SDK must include a privacy manifest file. Please contact the provider of the SDK that includes this file to get an updated SDK version with a privacy manifest. For more details about this policy, including a list of SDKs that are required to include signatures and manifests, visit: https://developer.apple.com/support/third-party-SDK-requirements. 