### PR TITLE
Match Trio's override/temp-target colors for non-Loop backends

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -7,6 +7,22 @@ import UIKit
 
 import Charts
 
+/// Fill colors for the override and temp-target bars on the BG graph.
+///
+/// Loop draws overrides green and temp targets purple, while Trio (and other
+/// OpenAPS-based algorithms) use the inverse — overrides purple, temp targets
+/// green. We follow the active backend's convention so the colors match the
+/// looping app the user is running.
+enum TreatmentGraphColors {
+    static var override: NSUIColor {
+        Storage.shared.device.value == "Loop" ? .systemGreen : .systemPurple
+    }
+
+    static var tempTarget: NSUIColor {
+        Storage.shared.device.value == "Loop" ? .systemPurple : .systemGreen
+    }
+}
+
 enum GraphDataIndex: Int {
     case bg = 0
     case prediction = 1
@@ -201,7 +217,7 @@ class TempTargetRenderer: LineChartRenderer {
                 }
 
                 context.saveGState()
-                context.setFillColor(NSUIColor.systemPurple.withAlphaComponent(0.5).cgColor)
+                context.setFillColor(TreatmentGraphColors.tempTarget.withAlphaComponent(0.5).cgColor)
                 context.fill(rect)
                 context.restoreGState()
             }
@@ -381,7 +397,7 @@ extension MainViewController {
         lineOverride.lineWidth = 0
         lineOverride.drawFilledEnabled = true
         lineOverride.fillFormatter = OverrideFillFormatter()
-        lineOverride.fillColor = NSUIColor.systemGreen
+        lineOverride.fillColor = TreatmentGraphColors.override
         lineOverride.fillAlpha = 0.6
         lineOverride.drawCirclesEnabled = false
         lineOverride.axisDependency = YAxis.AxisDependency.right
@@ -1453,7 +1469,7 @@ extension MainViewController {
         lineOverride.lineWidth = 0
         lineOverride.drawFilledEnabled = true
         lineOverride.fillFormatter = OverrideFillFormatter()
-        lineOverride.fillColor = NSUIColor.systemGreen
+        lineOverride.fillColor = TreatmentGraphColors.override
         lineOverride.fillAlpha = 0.6
         lineOverride.drawCirclesEnabled = false
         lineOverride.axisDependency = YAxis.AxisDependency.right
@@ -1676,6 +1692,9 @@ extension MainViewController {
         var smallChart = BGChartFull.lineData!.dataSets[dataIndex] as! LineChartDataSet
         chart.clear()
         smallChart.clear()
+        // Refresh the fill color in case the backend (Loop vs Trio) changed.
+        chart.fillColor = TreatmentGraphColors.override
+        smallChart.fillColor = TreatmentGraphColors.override
         let thisData = overrideGraphData
 
         var colors = [NSUIColor]()

--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -80,7 +80,7 @@ extension MainViewController {
         }
 
         Observable.shared.override.value = activeOverrideNote
-        if Storage.shared.device.value == "Trio" {
+        if Storage.shared.device.value != "Loop" {
             if let note = activeOverrideNote {
                 infoManager.updateInfoData(type: .override, value: note)
             } else {


### PR DESCRIPTION
Overrides and temp targets were drawn with the colors swapped relative to Trio. In Trio an override is purple and a temp target is green; LoopFollow had them reversed.

Now non-Loop backends (Trio, OpenAPS) follow Trio's scheme — override purple, temp target green — while Loop keeps its existing colors (override green, temp target purple). The choice keys off the existing `device == "Loop"` convention, so it reacts to a backend change without recreating the graph.

Also switches the override info-row population in `Overrides.swift` from `== "Trio"` to `!= "Loop"` so it applies to all non-Loop backends.