### PR TITLE
Remove empty Nightscout group left over from #618

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -1092,7 +1092,6 @@
 			children = (
 				B500000000000000000000A5 /* QuickPickBoluses */,
 				B500000000000000000000B5 /* QuickPickMeals */,
-				DDDF6F4A2D479B6A00884336 /* Nightscout */,
 				DDEF503E2D479B8A00884336 /* LoopAPNS */,
 				DD4878112C7B74F90048F05C /* TRC */,
 				DD4878062C7B2E9E0048F05C /* Settings */,
@@ -1386,13 +1385,6 @@
 				DDDC31CB2E13A7DF009EA0F3 /* AddAlarmSheet.swift */,
 			);
 			path = AddAlarm;
-			sourceTree = "<group>";
-		};
-		DDDF6F4A2D479B6A00884336 /* Nightscout */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Nightscout;
 			sourceTree = "<group>";
 		};
 		DDEF503D2D32753A00999A5D /* Task */ = {


### PR DESCRIPTION
## Summary
- #618 removed the Nightscout-based remote command path, deleting the only file under `LoopFollow/Remote/Nightscout/`.
- The now-empty `Nightscout` `PBXGroup` was left behind in `project.pbxproj`, still referencing a folder with no contents.
- This removes the orphaned group and its reference from the parent Remote group. No source or build changes.