### PR TITLE
CI: Re-run lint when a PR's base branch changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ run-name: Lint (${{ github.head_ref || github.ref_name }})
 
 on:
   pull_request:
+    # 'edited' so the lint re-runs when a PR's base branch is changed; otherwise
+    # retargeting (e.g. main -> dev) leaves the required SwiftFormat check with no
+    # run on the new base and the PR stays blocked indefinitely.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +19,9 @@ permissions:
 jobs:
   swiftformat:
     name: SwiftFormat
+    # Run on open/sync/reopen always; on 'edited' only when the base branch
+    # actually changed, so routine title/description edits don't re-lint.
+    if: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
     runs-on: ubuntu-latest
     container: swift:6.0
     steps:


### PR DESCRIPTION
## What

Add `edited` to the lint workflow's `pull_request` trigger, guarded so the `SwiftFormat` job only re-runs when the PR's **base branch** actually changed (not on routine title/description edits).

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened, edited]

jobs:
  swiftformat:
    if: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
```

## Why

A real PR got stuck "pending" indefinitely (#653) and this is the fix.

The default `pull_request` trigger types are `[opened, synchronize, reopened]`. **Changing a PR's base branch fires `pull_request: edited`** — which none of those cover — so the lint workflow does not re-run on a retarget.

That matters because `SwiftFormat` is a **required status check** on `dev`. The failure sequence:

1. A PR is opened against `main` (common for new/outside contributors).
2. It gets retargeted `main` → `dev`. This fires only `edited`, so lint does not re-run.
3. The `dev` ruleset now requires `SwiftFormat`, but no run ever reported it on the new base. GitHub shows it as *"Expected — waiting for status to be reported"* and the PR stays **BLOCKED** forever, with no run to even approve.

Re-running lint on a base change ensures the required check actually reports against the new base. The `if` guard keeps it from re-linting on every title/body edit (which also fire `edited`).

Note: this does not change the fork-PR approval gate — runs on outside-contributor forks still need a maintainer to approve them — but it guarantees there is a run to approve after a retarget, instead of a phantom required check.