### PR TITLE
Prefer structured ISF/CR from device status over reason string

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -32,7 +32,9 @@ extension MainViewController {
             // ISF
             let profileISF = profileManager.currentISF()
             var enactedISF: HKQuantity?
-            if let enactedISFValue = enactedOrSuggested["ISF"] as? Double {
+            // Some uploaders (e.g. Trio Swift oref with dynamic ISF) report a
+            // placeholder 0 in the structured ISF field; treat that as missing.
+            if let enactedISFValue = enactedOrSuggested["ISF"] as? Double, enactedISFValue != 0 {
                 enactedISF = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: enactedISFValue)
             }
             if let profileISF = profileISF, let enactedISF = enactedISF, profileISF != enactedISF {
@@ -44,9 +46,14 @@ extension MainViewController {
             }
 
             // Carb Ratio (CR)
+            // Prefer the structured CR field; fall back to parsing it out of the
+            // reason string for uploaders that don't expose it (a CR of 0 is never
+            // valid, so it's treated as missing).
             let profileCR = profileManager.currentCarbRatio()
             var enactedCR: Double?
-            if let reasonString = enactedOrSuggested["reason"] as? String {
+            if let structuredCR = enactedOrSuggested["CR"] as? Double, structuredCR != 0 {
+                enactedCR = structuredCR
+            } else if let reasonString = enactedOrSuggested["reason"] as? String {
                 let pattern = "CR: (\\d+(?:\\.\\d+)?)"
                 if let regex = try? NSRegularExpression(pattern: pattern) {
                     let nsString = reasonString as NSString


### PR DESCRIPTION
When showing ISF and Carb Ratio in the info table, LoopFollow reads from the most recent `enacted`/`suggested` record in device status.

**ISF** was taken straight from the structured `ISF` field without validation. The value is now validated, and a `0` is treated as missing, so the info row falls back to the profile ISF instead of rendering `profileISF → 0`.

**Carb Ratio** was parsed out of the `reason` string by regex, even though device status already carries a structured `CR` field. CR now reads from the structured field when present (and non-zero), keeping the `reason`-string regex only as a fallback for uploaders that don't expose it. Parsing the structured number is more robust than matching free text across oref versions.