### PR TITLE
Fix tab bar labels wrapping at large Dynamic Type sizes

### DIFF
--- a/LoopFollow/Application/AppDelegate.swift
+++ b/LoopFollow/Application/AppDelegate.swift
@@ -13,6 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         LogManager.shared.log(category: .general, message: "App started")
         LogManager.shared.cleanupOldLogs()
 
+        configureTabBarAppearance()
+
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
         notificationCenter.requestAuthorization(options: options) {
             didAllow, _ in
@@ -85,6 +87,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return true
+    }
+
+    // MARK: - Tab bar appearance
+
+    /// Pin the tab bar item titles to a fixed, non-scaling font so large
+    /// Dynamic Type sizes don't wrap or truncate the labels.
+    private func configureTabBarAppearance() {
+        // 10pt medium matches the system default tab bar label.
+        let titleFont = UIFont.systemFont(ofSize: 10, weight: .medium)
+        let attributes: [NSAttributedString.Key: Any] = [.font: titleFont]
+
+        func apply(to itemAppearance: UITabBarItemAppearance) {
+            itemAppearance.normal.titleTextAttributes = attributes
+            itemAppearance.selected.titleTextAttributes = attributes
+            itemAppearance.disabled.titleTextAttributes = attributes
+            itemAppearance.focused.titleTextAttributes = attributes
+        }
+
+        let appearance = UITabBarAppearance()
+        apply(to: appearance.stackedLayoutAppearance)
+        apply(to: appearance.inlineLayoutAppearance)
+        apply(to: appearance.compactInlineLayoutAppearance)
+
+        UITabBar.appearance().standardAppearance = appearance
+        UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 
     // MARK: - BFU recovery

--- a/LoopFollow/Application/MainTabView.swift
+++ b/LoopFollow/Application/MainTabView.swift
@@ -25,7 +25,7 @@ struct MainTabView: View {
             ForEach(Array(orderedItems.prefix(4).enumerated()), id: \.element) { index, item in
                 tabContent(for: item)
                     .tabItem {
-                        Label(item.displayName, systemImage: item.icon)
+                        tabLabel(item.displayName, systemImage: item.icon)
                     }
                     .tag(index)
             }
@@ -34,7 +34,7 @@ struct MainTabView: View {
                 MoreMenuView()
             }
             .tabItem {
-                Label("Menu", systemImage: "line.3.horizontal")
+                tabLabel("Menu", systemImage: "line.3.horizontal")
             }
             .tag(4)
         }
@@ -59,6 +59,21 @@ struct MainTabView: View {
             // User must explicitly choose — no swipe-to-dismiss.
             TelemetryConsentView()
                 .interactiveDismissDisabled(true)
+        }
+    }
+
+    /// Tab bar label with a fixed-size icon so large Dynamic Type sizes don't
+    /// grow the symbol and squeeze the title. The title font is pinned in AppDelegate.
+    private func tabLabel(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title)
+        } icon: {
+            let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
+            if let image = UIImage(systemName: systemImage, withConfiguration: config) {
+                Image(uiImage: image.withRenderingMode(.alwaysTemplate))
+            } else {
+                Image(systemName: systemImage)
+            }
         }
     }
 


### PR DESCRIPTION
At large accessibility text sizes the tab bar titles wrapped and truncated ("Re…", "Sno…") because both the title font and the SF Symbol icons scaled with Dynamic Type, leaving no room in the fixed-height tab bar.

This pins the title font (global `UITabBar` appearance) and the icons (fixed-size symbol images) to a constant size. Works regardless of which tabs the user has placed in the bar.