### PR TITLE
release.sh: verify latest script before running

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -68,6 +68,18 @@ update_follower () {
 PRIMARY_ABS_PATH="$(pwd -P)"
 echo "🏁  Working in $PRIMARY_ABS_PATH …"
 
+# --- guard: make sure we're running the latest release.sh from origin/dev ----
+# The release flow assumes the newest script. If this copy differs from the one
+# on origin/dev, we're likely running a stale version — abort and tell the user.
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+echo_run git fetch origin "$DEV_BRANCH"
+if ! diff -q <(git show "origin/${DEV_BRANCH}:release.sh") "$SCRIPT_PATH" >/dev/null 2>&1; then
+  echo "❌  This release.sh does not match origin/${DEV_BRANCH}:release.sh."
+  echo "    You're likely running an outdated copy of the release script."
+  echo "    Switch to the latest '${DEV_BRANCH}' (git switch ${DEV_BRANCH} && git pull) and re-run. Aborting."
+  exit 1
+fi
+
 # --- start out in main to capture old_ver ---- 
 echo_run git switch "$MAIN_BRANCH"
 echo_run git fetch


### PR DESCRIPTION
Guards the release flow against running an outdated copy of `release.sh`.

Before any git operations, the script now fetches `origin/dev` and compares the running script (`${BASH_SOURCE[0]}`) against `origin/dev:release.sh`. If they differ, it aborts with guidance to switch to the latest `dev` and re-run.

This catches the cases where a stale script would otherwise run:
- launched from an old branch
- on `dev` but behind `origin/dev`

The check is on script content, not branch — the release flow switches branches itself, so what matters is that the logic being executed is current.