### PR TITLE
release.sh: drop [skip ci] from version bump; allow manual tag_on_main

### DIFF
--- a/.github/workflows/tag_on_main.yml
+++ b/.github/workflows/tag_on_main.yml
@@ -17,6 +17,10 @@ on:
   push:
     branches:
       - main
+  # Manual fallback: if the push-triggered run was ever skipped (e.g. a commit
+  # with [skip ci] landing on main), the tag can be created by dispatching this
+  # workflow against main. It is idempotent — it skips if the tag already exists.
+  workflow_dispatch:
 
 jobs:
   tag:

--- a/release.sh
+++ b/release.sh
@@ -104,7 +104,10 @@ echo_run git switch -c "$RELEASE_BRANCH"
 # --- bump version on the release branch ----
 sed -i '' "s/${MARKETING_KEY}[[:space:]]*=.*/${MARKETING_KEY} = ${new_ver}/" "$VERSION_FILE"
 echo_run git diff "$VERSION_FILE"; pause
-echo_run git commit -m "update version to ${new_ver} [skip ci]" "$VERSION_FILE"
+# No [skip ci] here on purpose: it would skip the required SwiftFormat lint check
+# (leaving the release PRs blocked) and the tag_on_main workflow (no auto-tag).
+# auto_version_dev already avoids re-bumping via its "Config.xcconfig changed" guard.
+echo_run git commit -m "update version to ${new_ver}" "$VERSION_FILE"
 
 echo "💻  Build & test release branch now."; pause
 queue_push push origin "$RELEASE_BRANCH"


### PR DESCRIPTION
The `[skip ci]` on the release version-bump commit had two harmful side effects observed during the v6.2.0 release:

- It skipped the required **SwiftFormat** lint check, leaving the release PRs stuck at `BLOCKED` (requiring a manual override to merge).
- It skipped **tag_on_main.yml**, so the `v6.2.0` tag was never created automatically and had to be pushed by hand.

The `[skip ci]` was only there to stop `auto_version_dev` from re-bumping when the commit lands on `dev` — but that workflow already prevents this via its own "Skip if Config.xcconfig was changed in this push" guard. So the token is redundant for its intended purpose and is removed.

Also adds a `workflow_dispatch` trigger to `tag_on_main.yml` as a safety net: if a tagging run is ever skipped, the tag can be created by dispatching the workflow against `main` (idempotent — it skips if the tag already exists).

Note: once this is merged, the `SwiftFormat` requirement can safely be enabled for `main` (Phase 3) without blocking future release PRs.