### PR TITLE
release.sh: use merge-commit for release PRs to preserve release notes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -146,7 +146,7 @@ if [[ $confirm =~ ^[Yy]$ ]]; then
 
 \`auto_version_dev\` detects that \`Config.xcconfig\` was changed in this push and skips re-bumping.
 
-⚠️ **Use rebase-merge** (not squash or merge-commit) so \`dev\` and \`main\` end up at the same commit SHA after the release."
+⚠️ **Use \"Create a merge commit\"** (not squash or rebase) so \`dev\` and \`main\` share the same release lineage."
 
   echo; echo "📝  Opening release PR ${RELEASE_BRANCH} → ${MAIN_BRANCH} …"
   gh pr create \
@@ -157,7 +157,7 @@ if [[ $confirm =~ ^[Yy]$ ]]; then
 
 Merging this PR triggers the tagging workflow, which creates tag \`v${new_ver}\` from \`LOOP_FOLLOW_MARKETING_VERSION\` in \`Config.xcconfig\`.
 
-⚠️ **Use rebase-merge** (not squash or merge-commit) so \`dev\` and \`main\` end up at the same commit SHA after the release."
+⚠️ **Use \"Create a merge commit\"** (not squash or rebase) so \`main\` keeps the original feature-PR commits. Rebase rewrites them to new SHAs, which breaks GitHub's auto-generated release notes (no PR list, only the release author is credited) and diverges \`main\` from \`dev\`."
 
   echo; echo "🎉  All repos updated to v${new_ver} (local). Release PRs opened (sync → dev, release → main)."
   echo "👉  Review and merge both PRs — the tag will be created automatically by .github/workflows/tag_on_main.yml."

--- a/release.sh
+++ b/release.sh
@@ -157,7 +157,7 @@ if [[ $confirm =~ ^[Yy]$ ]]; then
 
 Merging this PR triggers the tagging workflow, which creates tag \`v${new_ver}\` from \`LOOP_FOLLOW_MARKETING_VERSION\` in \`Config.xcconfig\`.
 
-⚠️ **Use \"Create a merge commit\"** (not squash or rebase) so \`main\` keeps the original feature-PR commits. Rebase rewrites them to new SHAs, which breaks GitHub's auto-generated release notes (no PR list, only the release author is credited) and diverges \`main\` from \`dev\`."
+⚠️ **Use \"Create a merge commit\"** (not squash or rebase) so \`main\` keeps the original feature-PR commits."
 
   echo; echo "🎉  All repos updated to v${new_ver} (local). Release PRs opened (sync → dev, release → main)."
   echo "👉  Review and merge both PRs — the tag will be created automatically by .github/workflows/tag_on_main.yml."


### PR DESCRIPTION
## Background

The previous (non-PR) release flow merged `dev` into `main` with a fast-forward `git merge`, so `main` contained the actual feature-PR commits. GitHub's auto-generated release notes walked those commits and produced a full, correctly-attributed changelog.

Moving the release flow to PRs (#649) switched to **rebase-merge**, which rewrites those commits to new SHAs on `main`. As a result, for v6.2.0:

- the auto-generated release notes credited only the release author and listed no feature PRs, and
- `main` and `dev` ended up on divergent histories (identical content, different SHAs).

## Change

Updates the guidance in both release PR bodies generated by `release.sh` from "use rebase-merge … same commit SHA" to **"Create a merge commit"**. Merging (instead of rebasing) keeps the original feature-PR commits on `main`, which:

- restores correct auto-generated release notes (full PR list + contributors), and
- re-aligns `main` with `dev`'s lineage on the next release (the merge commit pulls `dev`'s history back into `main`).

The same-SHA promise is dropped — it was a leftover from the old fast-forward flow and is not achievable through GitHub's PR merge buttons, none of which fast-forward.