### PR TITLE
Sanitize Nightscout token to prevent WebSocket crash on launch

### DIFF
--- a/LoopFollow/Controllers/Nightscout/NightscoutSocketManager.swift
+++ b/LoopFollow/Controllers/Nightscout/NightscoutSocketManager.swift
@@ -40,10 +40,10 @@ class NightscoutSocketManager {
             return
         }
 
-        let url = Storage.shared.url.value
-        // Sanitize defensively: tokens saved before this fix may still hold a stray
+        // Sanitize defensively: values saved before this fix may still hold a stray
         // whitespace/control char that crashes Socket.IO's URL builder on iOS 26.
-        let token = NightscoutUtils.sanitizeToken(Storage.shared.token.value)
+        let url = NightscoutUtils.sanitizeConnectionInput(Storage.shared.url.value)
+        let token = NightscoutUtils.sanitizeConnectionInput(Storage.shared.token.value)
 
         guard !url.isEmpty else {
             disconnect()

--- a/LoopFollow/Controllers/Nightscout/NightscoutSocketManager.swift
+++ b/LoopFollow/Controllers/Nightscout/NightscoutSocketManager.swift
@@ -41,7 +41,9 @@ class NightscoutSocketManager {
         }
 
         let url = Storage.shared.url.value
-        let token = Storage.shared.token.value
+        // Sanitize defensively: tokens saved before this fix may still hold a stray
+        // whitespace/control char that crashes Socket.IO's URL builder on iOS 26.
+        let token = NightscoutUtils.sanitizeToken(Storage.shared.token.value)
 
         guard !url.isEmpty else {
             disconnect()

--- a/LoopFollow/Helpers/NightscoutUtils.swift
+++ b/LoopFollow/Helpers/NightscoutUtils.swift
@@ -162,6 +162,15 @@ class NightscoutUtils {
         return request
     }
 
+    // Strip whitespace/newlines/control characters that can sneak in via paste.
+    // A raw one breaks WebSocket connect (invalid percent-encoded query traps on iOS 26).
+    static func sanitizeToken(_ token: String) -> String {
+        token.unicodeScalars
+            .filter { !CharacterSet.whitespacesAndNewlines.contains($0) && !CharacterSet.controlCharacters.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
     static func constructURL(baseURL: String, token: String?, endpoint: String, parameters: [String: String]) -> URL? {
         var components = URLComponents(string: baseURL)
         components?.path = endpoint

--- a/LoopFollow/Helpers/NightscoutUtils.swift
+++ b/LoopFollow/Helpers/NightscoutUtils.swift
@@ -163,9 +163,11 @@ class NightscoutUtils {
     }
 
     // Strip whitespace/newlines/control characters that can sneak in via paste.
-    // A raw one breaks WebSocket connect (invalid percent-encoded query traps on iOS 26).
-    static func sanitizeToken(_ token: String) -> String {
-        token.unicodeScalars
+    // Neither a URL nor a token may legally contain them, and a stray one breaks
+    // WebSocket connect (invalid percent-encoded query traps on iOS 26) or makes
+    // URL parsing fall back to a lossy cleanup that mangles the address.
+    static func sanitizeConnectionInput(_ input: String) -> String {
+        input.unicodeScalars
             .filter { !CharacterSet.whitespacesAndNewlines.contains($0) && !CharacterSet.controlCharacters.contains($0) }
             .map(String.init)
             .joined()

--- a/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
+++ b/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
@@ -27,7 +27,7 @@ class NightscoutSettingsViewModel: ObservableObject {
     @Published var nightscoutToken: String = Storage.shared.token.value {
         willSet {
             if newValue != nightscoutToken {
-                Storage.shared.token.value = newValue
+                Storage.shared.token.value = NightscoutUtils.sanitizeToken(newValue)
                 triggerCheckStatus()
             }
         }

--- a/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
+++ b/LoopFollow/Nightscout/NightscoutSettingsViewModel.swift
@@ -27,7 +27,7 @@ class NightscoutSettingsViewModel: ObservableObject {
     @Published var nightscoutToken: String = Storage.shared.token.value {
         willSet {
             if newValue != nightscoutToken {
-                Storage.shared.token.value = NightscoutUtils.sanitizeToken(newValue)
+                Storage.shared.token.value = NightscoutUtils.sanitizeConnectionInput(newValue)
                 triggerCheckStatus()
             }
         }
@@ -93,6 +93,12 @@ class NightscoutSettingsViewModel: ObservableObject {
     }
 
     func processURL(_ value: String) {
+        // Strip whitespace/newlines/control chars first. A URL can't legally contain
+        // them, and a stray one (e.g. a trailing newline from a paste) otherwise makes
+        // URLComponents parsing fail and falls through to the lossy fallback below,
+        // mangling a URL-with-embedded-token into an invalid address.
+        let value = NightscoutUtils.sanitizeConnectionInput(value)
+
         var useTokenUrl = false
 
         if let urlComponents = URLComponents(string: value), let queryItems = urlComponents.queryItems {


### PR DESCRIPTION
## Problem

LoopFollow crashes on startup (the reporting user has TestFlight 6.2.0, iPad on iOS 26.5) with an `EXC_BREAKPOINT`/SIGTRAP from `URLComponents.percentEncodedQuery`'s setter, reached through Socket.IO's `createURLs()` while opening the Nightscout WebSocket in `MainViewController.viewDidLoad`.

The Nightscout WebSocket (Socket.IO) is new in 6.2.0, so this is the first build that exercises this path. Socket.IO builds its connect URL query from the `token` we pass in `connectParams`, and its `urlEncode()` doesn't escape whitespace/control characters. On iOS 26 the `percentEncodedQuery` setter is strict and traps on a string that isn't already valid percent-encoding. So a token holding a stray character (e.g. a trailing newline from a paste) produces an invalid query and crashes the app at launch.

## Fix

- Add `NightscoutUtils.sanitizeToken(_:)`, which strips whitespace, newlines, and control characters.
- Sanitize the token when it's written from the Nightscout settings screen.
- Sanitize defensively at WebSocket connect time so already-saved bad tokens stop crashing without the user re-entering anything.

Verified by the user reporting the issue, it's no longer crashing on startup and works like it should