### PR TITLE
Skip alarm checks until BFU reload completes

### DIFF
--- a/LoopFollow/Alarm/AlarmManager.swift
+++ b/LoopFollow/Alarm/AlarmManager.swift
@@ -42,6 +42,12 @@ class AlarmManager {
     }
 
     func checkAlarms(data: AlarmData) {
+        // Don't evaluate against stale pre-unlock state before the BFU reload runs.
+        if Storage.shared.needsBFUReload {
+            LogManager.shared.log(category: .alarm, message: "Skipping alarm check — BFU reload pending", isDebug: true)
+            return
+        }
+
         let now = Date()
         var alarmTriggered = false
 


### PR DESCRIPTION
On a Before-First-Unlock cold launch, the alarm task can run before `performBFUReloadIfNeeded()` reloads StorageValues. During that window the alarm list (and its snooze state), `lastBGChecked`, and alarm configuration are still stale pre-unlock values, so a spurious Missed Reading alert can sound before real state is loaded.

`checkAlarms` now returns early while `needsBFUReload` is true; the next scheduled tick evaluates normally once the reload completes.