### PR TITLE
Format Rec. Bolus with the pump's bolus increment

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -100,10 +100,9 @@ extension MainViewController {
                 infoManager.clearInfoData(type: .minMax)
                 updatePredictionGraph()
             }
-            if let recBolus = lastLoopRecord["recommendedBolus"] as? Double {
-                let formattedRecBolus = String(format: "%.2fU", recBolus)
-                infoManager.updateInfoData(type: .recBolus, value: formattedRecBolus)
-                Observable.shared.deviceRecBolus.value = recBolus
+            if let recBolus = InsulinMetric(from: lastLoopRecord, key: "recommendedBolus") {
+                infoManager.updateInfoData(type: .recBolus, value: recBolus)
+                Observable.shared.deviceRecBolus.value = recBolus.value
             }
             if let loopStatus = lastLoopRecord["recommendedTempBasal"] as? [String: AnyObject] {
                 if let tempBasalTime = formatter.date(from: (loopStatus["timestamp"] as! String))?.timeIntervalSince1970 {

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -100,9 +100,12 @@ extension MainViewController {
                 infoManager.clearInfoData(type: .minMax)
                 updatePredictionGraph()
             }
-            if let recBolus = InsulinMetric(from: lastLoopRecord, key: "recommendedBolus") {
-                infoManager.updateInfoData(type: .recBolus, value: recBolus)
-                Observable.shared.deviceRecBolus.value = recBolus.value
+            if let recBolus = lastLoopRecord["recommendedBolus"] as? Double {
+                infoManager.updateInfoData(type: .recBolus, value: InsulinFormatter.shared.string(recBolus))
+                Observable.shared.deviceRecBolus.value = recBolus
+            } else {
+                infoManager.clearInfoData(type: .recBolus)
+                Observable.shared.deviceRecBolus.value = nil
             }
             if let loopStatus = lastLoopRecord["recommendedTempBasal"] as? [String: AnyObject] {
                 if let tempBasalTime = formatter.date(from: (loopStatus["timestamp"] as! String))?.timeIntervalSince1970 {

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -107,10 +107,11 @@ extension MainViewController {
             }
 
             // Recommended Bolus
-            if let rec = InsulinMetric(from: lastLoopRecord, key: "recommendedBolus") {
-                infoManager.updateInfoData(type: .recBolus, value: rec)
-                Observable.shared.deviceRecBolus.value = rec.value
+            if let rec = lastLoopRecord["recommendedBolus"] as? Double {
+                infoManager.updateInfoData(type: .recBolus, value: InsulinFormatter.shared.string(rec))
+                Observable.shared.deviceRecBolus.value = rec
             } else {
+                infoManager.clearInfoData(type: .recBolus)
                 Observable.shared.deviceRecBolus.value = nil
             }
 


### PR DESCRIPTION
Rec. Bolus was formatted two different ways. The Loop device status parser used a hardcoded `String(format: "%.2fU")`, while the OpenAPS/Trio parser went through `InsulinMetric`, which drops to one fraction digit below 10 U. The same recommendation rendered as `0.00U` in the info table on a Loop URL and `0` on a Trio URL.

Both parsers now use `InsulinFormatter`, which derives its fraction digits from the pump's reported `bolusIncrement`, so Rec. Bolus is shown at the precision the pump can actually deliver — two decimals for a 0.05 U DASH pod. The unit suffix is dropped to match the other insulin rows in the info table.

When the device status carries no recommendation, the info row and `deviceRecBolus` are now cleared. Previously the Loop parser left both stale, so an old recommendation could linger in the info table, the Rec. Bolus alarm condition, and the Live Activity.