### PR TITLE
Restore Loop forecast after a refresh clears it

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusLoop.swift
@@ -68,7 +68,7 @@ extension MainViewController {
                 let prediction = predictdata["values"] as! [Double]
                 Observable.shared.predictionText.value = Localizer.toDisplayUnits(String(Int(round(prediction.last!))))
                 Observable.shared.predictionColor.value = .purple
-                if Storage.shared.downloadPrediction.value, previousLastLoopTime < lastLoopTime {
+                if Storage.shared.downloadPrediction.value, previousLastLoopTime < lastLoopTime || predictionData.isEmpty {
                     predictionData.removeAll()
                     var predictionTime = lastLoopTime
                     let toLoad = Int(Storage.shared.predictionToLoad.value * 12)


### PR DESCRIPTION
On Loop data sources, the glucose forecast is drawn on first load but disappears after a refresh and does not reappear until the next loop cycle.

`refresh()` clears `predictionData` and redraws an empty forecast. It runs on pull-to-refresh, on data-source reconfiguration, and on every WebSocket disconnect (which posts the `refresh` notification). The Loop forecast is only rebuilt in `DeviceStatusLoop`, and only when a newer loop cycle arrives (`previousLastLoopTime < lastLoopTime`). Because the current cycle has already been seen at that point, the forecast stays blank until the pump clock advances — up to five minutes, and longer when the WebSocket disconnects repeatedly.

Rebuild the forecast when `predictionData` is empty as well, so the next device-status poll restores it regardless of cycle timing. Same-cycle polls that already have forecast points continue to skip the rebuild. This mirrors the OpenAPS/Trio path, which already repopulates its prediction unconditionally and is unaffected.