### PR TITLE
Add fallbacks for missing TDD and timestamp in devicestatus

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -20,8 +20,6 @@ extension MainViewController {
 
             var updatedTime: TimeInterval?
 
-            // Prefer deliverAt: Trio copies it into timestamp when both exist, but
-            // some uploads (Trio SMB follow-ups, oref0 rigs) only carry deliverAt.
             if let timestamp = enactedOrSuggested["deliverAt"] as? String ?? enactedOrSuggested["timestamp"] as? String,
                let parsedTime = formatter.date(from: timestamp)?.timeIntervalSince1970
             {
@@ -164,8 +162,6 @@ extension MainViewController {
             }
 
             // TDD
-            // Trio's SMB follow-up uploads re-send a suggested object without TDD;
-            // the enacted object in the same record still has it.
             if let tddMetric = InsulinMetric(from: enactedOrSuggested, key: "TDD")
                 ?? InsulinMetric(from: lastLoopRecord["enacted"], key: "TDD")
             {

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -20,7 +20,9 @@ extension MainViewController {
 
             var updatedTime: TimeInterval?
 
-            if let timestamp = enactedOrSuggested["timestamp"] as? String,
+            // Prefer deliverAt: Trio copies it into timestamp when both exist, but
+            // some uploads (Trio SMB follow-ups, oref0 rigs) only carry deliverAt.
+            if let timestamp = enactedOrSuggested["deliverAt"] as? String ?? enactedOrSuggested["timestamp"] as? String,
                let parsedTime = formatter.date(from: timestamp)?.timeIntervalSince1970
             {
                 updatedTime = parsedTime
@@ -162,7 +164,11 @@ extension MainViewController {
             }
 
             // TDD
-            if let tddMetric = InsulinMetric(from: enactedOrSuggested, key: "TDD") {
+            // Trio's SMB follow-up uploads re-send a suggested object without TDD;
+            // the enacted object in the same record still has it.
+            if let tddMetric = InsulinMetric(from: enactedOrSuggested, key: "TDD")
+                ?? InsulinMetric(from: lastLoopRecord["enacted"], key: "TDD")
+            {
                 infoManager.updateInfoData(type: .tdd, value: tddMetric)
                 Storage.shared.lastTdd.value = tddMetric.value
             }


### PR DESCRIPTION
Some Trio uploads have a suggested object without TDD and timestamp, which left the TDD and Updated rows blank until the next loop cycle.

TDD now falls back to the enacted object when suggested doesn't have it, and Updated uses deliverAt with timestamp as fallback.