### PR TITLE
Use NightscoutUtils.constructURL for the Nightscout web viewer URL

### DIFF
--- a/LoopFollow/Helpers/NightscoutUtils.swift
+++ b/LoopFollow/Helpers/NightscoutUtils.swift
@@ -190,7 +190,10 @@ class NightscoutUtils {
             queryItems.append(URLQueryItem(name: key, value: value))
         }
 
-        components?.queryItems = queryItems
+        // Assigning an empty array would still append a bare "?" to the URL.
+        if !queryItems.isEmpty {
+            components?.queryItems = queryItems
+        }
 
         return components?.url
     }

--- a/LoopFollow/ViewControllers/NightScoutViewController.swift
+++ b/LoopFollow/ViewControllers/NightScoutViewController.swift
@@ -37,14 +37,12 @@ class NightscoutViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-        var url = Storage.shared.url.value
-        let token = Storage.shared.token.value
-
-        if token != "" {
-            url = url + "?token=" + token
-        }
-
-        guard let myUrl = URL(string: url) else { return }
+        guard let myUrl = NightscoutUtils.constructURL(
+            baseURL: Storage.shared.url.value,
+            token: Storage.shared.token.value,
+            endpoint: "",
+            parameters: [:]
+        ) else { return }
 
         let webpagePreferences = WKWebpagePreferences()
         webpagePreferences.allowsContentJavaScript = true


### PR DESCRIPTION
The Nightscout web viewer built its URL by concatenating the token onto the base URL without any encoding, so a token containing characters like & or = would be silently mangled. It now goes through NightscoutUtils.constructURL, which percent-encodes the token. For a normal token the resulting URL is identical to before.

constructURL also skips assigning queryItems when there is nothing to add, so a setup without a token no longer gets a stray trailing question mark.