### PR TITLE
Remove unneeded UIKit imports

### DIFF
--- a/LoopFollow/BackgroundRefresh/BT/BluetoothDevice.swift
+++ b/LoopFollow/BackgroundRefresh/BT/BluetoothDevice.swift
@@ -4,7 +4,6 @@
 import CoreBluetooth
 import Foundation
 import os
-import UIKit
 
 class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     weak var bluetoothDeviceDelegate: BluetoothDeviceDelegate?

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -2,7 +2,6 @@
 // NightScout.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     // NS Cage Struct

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -2,7 +2,6 @@
 // BGData.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     /// Number of days of BG history to request from the source. One extra day is

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -3,7 +3,6 @@
 
 import Foundation
 import HealthKit
-import UIKit
 
 extension MainViewController {
     func DeviceStatusOpenAPS(formatter: ISO8601DateFormatter, lastDeviceStatus: [String: AnyObject]?, lastLoopRecord: [String: AnyObject]) {

--- a/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/BGCheck.swift
@@ -2,7 +2,6 @@
 // BGCheck.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     // NS BG Check Response Processor

--- a/LoopFollow/Controllers/Nightscout/Treatments/Notes.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Notes.swift
@@ -2,7 +2,6 @@
 // Notes.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     // NS Note Response Processor

--- a/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/Overrides.swift
@@ -2,7 +2,6 @@
 // Overrides.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     func processNSOverrides(entries: [[String: AnyObject]]) {

--- a/LoopFollow/Controllers/Nightscout/Treatments/TemporaryTarget.swift
+++ b/LoopFollow/Controllers/Nightscout/Treatments/TemporaryTarget.swift
@@ -3,7 +3,6 @@
 
 import Foundation
 import HealthKit
-import UIKit
 
 extension MainViewController {
     // NS Temporary Target Response Processor

--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -2,7 +2,6 @@
 // Timers.swift
 
 import Foundation
-import UIKit
 
 extension MainViewController {
     func startGraphNowTimer(time: TimeInterval = 60) {

--- a/LoopFollow/Helpers/BackgroundRefreshManager.swift
+++ b/LoopFollow/Helpers/BackgroundRefreshManager.swift
@@ -2,7 +2,7 @@
 // BackgroundRefreshManager.swift
 
 import BackgroundTasks
-import UIKit
+import Foundation
 
 class BackgroundRefreshManager {
     static let shared = BackgroundRefreshManager()

--- a/LoopFollow/Remote/Settings/RemoteSettingsView.swift
+++ b/LoopFollow/Remote/Settings/RemoteSettingsView.swift
@@ -4,7 +4,6 @@
 import AVFoundation
 import HealthKit
 import SwiftUI
-import UIKit
 
 struct RemoteSettingsView: View {
     @ObservedObject var viewModel: RemoteSettingsViewModel

--- a/LoopFollow/Settings/ImportExport/ImportExportSettingsView.swift
+++ b/LoopFollow/Settings/ImportExport/ImportExportSettingsView.swift
@@ -3,7 +3,6 @@
 
 import AVFoundation
 import SwiftUI
-import UIKit
 
 struct ImportExportSettingsView: View {
     @StateObject private var viewModel = ImportExportSettingsViewModel()

--- a/LoopFollow/Settings/SettingsMenuView.swift
+++ b/LoopFollow/Settings/SettingsMenuView.swift
@@ -339,8 +339,6 @@ struct AggregatedStatsViewWrapper: View {
 
 // MARK: – UIKit helpers (unchanged)
 
-import UIKit
-
 extension UIApplication {
     var topMost: UIViewController? {
         // `keyWindow` is deprecated and returns nil on Mac Catalyst / multi-window iPad.

--- a/LoopFollow/Stats/AggregatedStatsView.swift
+++ b/LoopFollow/Stats/AggregatedStatsView.swift
@@ -2,7 +2,6 @@
 // AggregatedStatsView.swift
 
 import SwiftUI
-import UIKit
 
 struct AggregatedStatsView: View {
     @ObservedObject var viewModel: AggregatedStatsViewModel

--- a/LoopFollow/Storage/Framework/StorageReadiness.swift
+++ b/LoopFollow/Storage/Framework/StorageReadiness.swift
@@ -3,7 +3,6 @@
 
 import Combine
 import Foundation
-import UIKit
 
 /// A cached value that can re-read itself from disk after a BFU launch.
 protocol BFUReloadable: AnyObject {

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -3,7 +3,6 @@
 
 import Foundation
 import HealthKit
-import UIKit
 
 /*
  Observable persistant storage

--- a/LoopFollow/Task/TaskScheduler.swift
+++ b/LoopFollow/Task/TaskScheduler.swift
@@ -2,7 +2,6 @@
 // TaskScheduler.swift
 
 import Foundation
-import UIKit
 
 enum TaskID: CaseIterable {
     case profile


### PR DESCRIPTION
Removes `import UIKit` from 16 files that don't use any UIKit API. `BackgroundRefreshManager.swift` gets `import Foundation` instead, since it was relying on UIKit re-exporting Foundation. Verified with a full workspace build.