### PR TITLE
Fix Mac Catalyst build

### DIFF
--- a/LoopFollow/Settings/SettingsMenuView.swift
+++ b/LoopFollow/Settings/SettingsMenuView.swift
@@ -129,7 +129,9 @@ enum SettingsRoute: Hashable, Identifiable {
         case .units: return ["mmol", "mgdl", "metrics"]
         case .infoDisplay: return ["info"]
         case .apn: return ["push", "notification"]
-        case .liveActivity: return ["dynamic island", "lock screen"]
+        #if !targetEnvironment(macCatalyst)
+            case .liveActivity: return ["dynamic island", "lock screen"]
+        #endif
         case .importExport: return ["import", "export", "backup"]
         default: return []
         }


### PR DESCRIPTION
The Menu search keywords added in #695 referenced the liveActivity settings route without the macCatalyst guard the rest of the code uses, which broke the Mac Catalyst build. This wraps that case in the same conditional. Both the Catalyst and iOS builds succeed.