### PR TITLE
Fix graph settings not honored on the small graph

### DIFF
--- a/LoopFollow/Charts/BGChartModel.swift
+++ b/LoopFollow/Charts/BGChartModel.swift
@@ -174,6 +174,7 @@ final class BGChartModel: ObservableObject {
     @Published var show30Min: Bool = false
     @Published var show90Min: Bool = false
     @Published var showMidnight: Bool = false
+    @Published var smallGraphTreatments: Bool = true
 
     private static let doseFormatter: NumberFormatter = {
         let nf = NumberFormatter()
@@ -405,6 +406,7 @@ final class BGChartModel: ObservableObject {
         show30Min = Storage.shared.show30MinLine.value
         show90Min = Storage.shared.show90MinLine.value
         showMidnight = Storage.shared.showMidnightLines.value
+        smallGraphTreatments = Storage.shared.smallGraphTreatments.value
 
         let isLoop = Storage.shared.device.value == "Loop"
         overrideColor = isLoop ? .green : .purple

--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -1011,21 +1011,28 @@ private struct BGChartCanvas: View, Equatable {
     }
 
     var body: some View {
+        let showTreatments = !isSmall || model.smallGraphTreatments
         let chart = Chart {
-            bgBandMarks
-            basalMarks
-            scheduledBasalMarks
+            if showTreatments {
+                bgBandMarks
+                basalMarks
+                scheduledBasalMarks
+            }
             coneMarks
-            yesterdayMarks
+            if !isSmall {
+                yesterdayMarks
+            }
             bgLineMarks
             bgPointsMark
             predictionLineMark
-            if !isSmall {
-                predictionVariantMarks
+            predictionVariantMarks
+            if showTreatments {
+                treatmentMarks
             }
-            treatmentMarks
             if !isSmall {
                 ruleMarks
+            } else if model.showMidnight {
+                midnightRuleMarks
             }
         }
         .chartXScale(domain: windowStart ... windowEnd)
@@ -1423,11 +1430,16 @@ private struct BGChartCanvas: View, Equatable {
             }
         }
         if model.showMidnight {
-            ForEach(model.midnightMarkers.filter { $0 >= windowStart && $0 <= windowEnd }, id: \.self) { d in
-                RuleMark(x: .value("midnight", d))
-                    .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [5, 3]))
-                    .foregroundStyle(Color.teal.opacity(0.6))
-            }
+            midnightRuleMarks
+        }
+    }
+
+    @ChartContentBuilder
+    private var midnightRuleMarks: some ChartContent {
+        ForEach(model.midnightMarkers.filter { $0 >= windowStart && $0 <= windowEnd }, id: \.self) { d in
+            RuleMark(x: .value("midnight", d))
+                .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [5, 3]))
+                .foregroundStyle(Color.teal.opacity(0.6))
         }
     }
 }

--- a/LoopFollow/Settings/GraphSettingsView.swift
+++ b/LoopFollow/Settings/GraphSettingsView.swift
@@ -56,9 +56,12 @@ struct GraphSettingsView: View {
             if nightscoutEnabled {
                 Section("Treatments") {
                     Toggle("Show Carb/Bolus Values", isOn: $showValues.value)
+                        .onChange(of: showValues.value) { _ in markDirty() }
                     Toggle("Show Carb Absorption", isOn: $showAbsorption.value)
+                        .onChange(of: showAbsorption.value) { _ in markDirty() }
                     Toggle("Treatments on Small Graph",
                            isOn: $smallGraphTreatments.value)
+                        .onChange(of: smallGraphTreatments.value) { _ in markDirty() }
                 }
             }
 


### PR DESCRIPTION
The Swift Charts migration (#704) lost some of the settings that control
what the small graph shows.

- "Treatments on Small Graph" was ignored. Treatments, basal, overrides
  and temp targets were always drawn, and flipping the toggle didn't
  refresh the chart.
- Midnight lines no longer showed on the small graph.
- With prediction style "Lines" the ZT/IOB/COB/UAM lines were missing
  from the small graph, so Trio users had no prediction there.
- Yesterday's BG was drawn on the small graph. The old chart only drew
  it on the main graph.

This restores the old behavior. The prediction cone stays visible on the
small graph. Also added the missing chart refresh to the "Show Carb/Bolus
Values" and "Show Carb Absorption" toggles so they apply right away
instead of on the next reading.

Tested in simulator:
- Toggling "Treatments on Small Graph" off hides boluses, carbs, SMBs,
  basal, overrides and temp targets on the small graph only, and they
  come back when toggled on again, without restarting the app.
- Midnight lines show on both graphs when enabled.
- Yesterday's BG shows on the main graph only.
- Cone style shows the cone and Lines style shows all four prediction
  lines on both graphs.
- Built for device and simulator via the workspace.