### PR TITLE
Draw temp targets at the BG level they target instead of in the override strip

### DIFF
--- a/LoopFollow/Charts/BGChartModel.swift
+++ b/LoopFollow/Charts/BGChartModel.swift
@@ -537,11 +537,14 @@ final class BGChartModel: ObservableObject {
         }
         tempTargets = vc.tempTargetGraphData.map {
             let target = $0.correctionRange.first.map { String($0) } ?? ""
+            // Temp targets render at the BG level they target (±5 mg/dL);
+            // only overrides live in the top strip.
+            let yCenter = Double($0.correctionRange.first ?? 0)
             return BandRect(
                 start: Date(timeIntervalSince1970: $0.date),
                 end: Date(timeIntervalSince1970: $0.endDate),
-                yBottom: yBottom,
-                yTop: yTop,
+                yBottom: yCenter - 5,
+                yTop: yCenter + 5,
                 label: "Temp Target",
                 pillText: "Temp Target\n\(Localizer.toDisplayUnits(target))\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))"
             )


### PR DESCRIPTION
The Swift Charts migration put temp target bands in the same strip at the top of the graph as overrides, so the two collided and the band no longer showed which BG level the temp target aims for. Before the migration the band was drawn at the target value, 5 mg/dL above and below it, with no label, and only overrides used the top strip. This restores that behavior. Verified with an override and a temp target active at the same time, on both the main and the small graph.