### PR TITLE
Use Trio's colors for the forecast curves

### DIFF
--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -1280,7 +1280,7 @@ private struct BGChartCanvas: View, Equatable {
                 y: .value("bg", pt.value),
                 series: .value("series", "zt")
             )
-            .foregroundStyle(Color(.systemGray))
+            .foregroundStyle(Color("ZT"))
             .lineStyle(StrokeStyle(lineWidth: 2))
         }
 
@@ -1290,7 +1290,7 @@ private struct BGChartCanvas: View, Equatable {
                 y: .value("bg", pt.value),
                 series: .value("series", "iob")
             )
-            .foregroundStyle(Color(.systemBlue))
+            .foregroundStyle(Color("Insulin"))
             .lineStyle(StrokeStyle(lineWidth: 2))
         }
 
@@ -1310,7 +1310,7 @@ private struct BGChartCanvas: View, Equatable {
                 y: .value("bg", pt.value),
                 series: .value("series", "uam")
             )
-            .foregroundStyle(Color(.systemPink))
+            .foregroundStyle(Color("UAM"))
             .lineStyle(StrokeStyle(lineWidth: 2))
         }
     }


### PR DESCRIPTION
The Swift Charts migration hardcoded system colors for the Trio/OpenAPS prediction lines, so they no longer matched what Trio shows. This switches ZT, IOB and UAM back to the ZT, Insulin and UAM asset colors, which are identical to the ones Trio uses. COB already renders in the same orange as Trio, so it is unchanged.