### PR TITLE
Clear stored predBGs when clearing the OpenAPS forecast

### DIFF
--- a/LoopFollow/Charts/BGChartStubs.swift
+++ b/LoopFollow/Charts/BGChartStubs.swift
@@ -87,9 +87,13 @@ extension MainViewController {
     }
 
     // Removes the Trio/OpenAPS forecast (ZT/IOB/COB/UAM lines and the cone). Used when the active system switches away from Trio/OpenAPS.
+    // Also drops the stored predBGs: the device observer calls updateOpenAPSPredictionDisplay after this runs,
+    // and would otherwise redraw the cleared forecast from them.
     func clearOpenAPSPredictionGraph() {
         let hasLineData = !ztPredictionData.isEmpty || !iobPredictionData.isEmpty || !cobPredictionData.isEmpty || !uamPredictionData.isEmpty
-        guard hasLineData || !chartModel.cone.isEmpty else { return }
+        guard hasLineData || !chartModel.cone.isEmpty || openAPSPredBGs != nil else { return }
+        openAPSPredBGs = nil
+        openAPSPredUpdatedTime = nil
         ztPredictionData = []
         iobPredictionData = []
         cobPredictionData = []


### PR DESCRIPTION
Switching from a Trio site to a Loop site left the old Trio forecast lines on the chart until the app was restarted. The switch itself is detected and clearOpenAPSPredictionGraph runs, but the device observer fires right after and calls updateOpenAPSPredictionDisplay, which drew the forecast again from the stored predBGs. Those are only cleared when an openaps record without predBGs arrives, which never happens on a Loop site. This clears the stored predBGs together with the drawn lines and cone, so there is nothing left to redraw from. The Loop to Trio direction already worked. Verified in the simulator against a live Trio and a live Loop site, switching in both directions.