### PR TITLE
Add App Intents to enable/disable BG speech via Shortcuts

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -97,12 +97,20 @@
 			exceptions = (
 				D736FE5E8494B2581A4EA95F /* Exceptions for "LoopFollow" folder in "LoopFollow" target */,
 			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
 			path = LoopFollow;
 			sourceTree = "<group>";
 		};
 		BC0FBFD3754955D028EF6631 /* Shared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -258,8 +266,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FC97882D2485969C00A7906C /* Build configuration list for PBXNativeTarget "LoopFollow" */;
 			buildPhases = (
-				DD7F4BEA2DD48B9600D449E9 /* Swiftformat */,
 				B038D39450A1F9A97D2B8BA4 /* [CP] Check Pods Manifest.lock */,
+				DD7F4BEA2DD48B9600D449E9 /* Swiftformat */,
 				FC9788102485969B00A7906C /* Sources */,
 				FC9788112485969B00A7906C /* Frameworks */,
 				FC9788122485969B00A7906C /* Resources */,
@@ -366,13 +374,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LoopFollow/Pods-LoopFollow-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LoopFollow/Pods-LoopFollow-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -490,7 +494,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoopFollowLAExtensionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -542,7 +546,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoopFollowLAExtensionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -591,7 +595,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -622,7 +626,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -772,7 +776,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LoopFollow/Loop Follow.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				INFOPLIST_FILE = LoopFollow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -797,7 +801,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LoopFollow/Loop Follow.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 4MFAGT7CVA;
 				INFOPLIST_FILE = LoopFollow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/LoopFollow/Controllers/SpeakBGIntents.swift
+++ b/LoopFollow/Controllers/SpeakBGIntents.swift
@@ -1,0 +1,24 @@
+// LoopFollow
+// SpeakBGIntents.swift
+
+import AppIntents
+
+struct EnableSpeakBGIntent: AppIntent {
+    static var title: LocalizedStringResource = "Enable BG Speech"
+    static var description = IntentDescription("Turns on spoken glucose readings in LoopFollow.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        Storage.shared.speakBG.value = true
+        return .result(dialog: "BG speech enabled.")
+    }
+}
+
+struct DisableSpeakBGIntent: AppIntent {
+    static var title: LocalizedStringResource = "Disable BG Speech"
+    static var description = IntentDescription("Turns off spoken glucose readings in LoopFollow.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        Storage.shared.speakBG.value = false
+        return .result(dialog: "BG speech disabled.")
+    }
+}

--- a/LoopFollow/LiveActivity/RestartLiveActivityIntent.swift
+++ b/LoopFollow/LiveActivity/RestartLiveActivityIntent.swift
@@ -32,13 +32,25 @@
         }
     }
 
-    struct LoopFollowAppShortcuts: AppShortcutsProvider {
+struct LoopFollowAppShortcuts: AppShortcutsProvider {
         static var appShortcuts: [AppShortcut] {
             AppShortcut(
                 intent: RestartLiveActivityIntent(),
                 phrases: ["Restart Live Activity in \(.applicationName)"],
                 shortTitle: "Restart Live Activity",
                 systemImageName: "dot.radiowaves.left.and.right"
+            )
+            AppShortcut(
+                intent: EnableSpeakBGIntent(),
+                phrases: ["Enable BG speech in \(.applicationName)"],
+                shortTitle: "Enable BG Speech",
+                systemImageName: "speaker.wave.2"
+            )
+            AppShortcut(
+                intent: DisableSpeakBGIntent(),
+                phrases: ["Disable BG speech in \(.applicationName)"],
+                shortTitle: "Disable BG Speech",
+                systemImageName: "speaker.slash"
             )
         }
     }


### PR DESCRIPTION
## What
Adds two App Intents (Enable/Disable BG Speech) so users can toggle
speakBG from the Shortcuts app or from a personal automation.

## Why
speakBG is useful when wearing Bluetooth headphones, but there's
currently no way to enable/disable it automatically (e.g. when
headphones connect/disconnect) without opening the app. This exposes
the existing speakBG toggle as two Shortcuts actions so users can
build their own automations (Bluetooth-triggered, time-based, etc.).

## Testing
Built and tested on-device (iOS 26.5.2) against dev branch. Confirmed
both actions appear in the Shortcuts app and correctly toggle
Storage.shared.speakBG.