### PR TITLE
Fix Advanced Settings graph toggles not hiding chart elements

### DIFF
--- a/LoopFollow/Charts/BGChartModel.swift
+++ b/LoopFollow/Charts/BGChartModel.swift
@@ -408,6 +408,14 @@ final class BGChartModel: ObservableObject {
         showMidnight = Storage.shared.showMidnightLines.value
         smallGraphTreatments = Storage.shared.smallGraphTreatments.value
 
+        // Advanced-settings visibility toggles. The Nightscout controllers
+        // collect the data regardless (it also feeds the info rows), so hidden
+        // kinds are dropped here at render time.
+        let showBasal = Storage.shared.graphBasal.value
+        let showBolus = Storage.shared.graphBolus.value
+        let showCarbs = Storage.shared.graphCarbs.value
+        let showOtherTreatments = Storage.shared.graphOtherTreatments.value
+
         let isLoop = Storage.shared.device.value == "Loop"
         overrideColor = isLoop ? .green : .purple
         tempTargetColor = isLoop ? .purple : .green
@@ -436,7 +444,7 @@ final class BGChartModel: ObservableObject {
         cobPrediction = vc.cobPredictionData.map { BGPoint(date: Date(timeIntervalSince1970: $0.date), value: Double($0.sgv), color: .purple) }
         uamPrediction = vc.uamPredictionData.map { BGPoint(date: Date(timeIntervalSince1970: $0.date), value: Double($0.sgv), color: .purple) }
 
-        let bolusPoints = vc.bolusData.map {
+        let bolusPoints = (showBolus ? vc.bolusData : []).map {
             let dose = self.formatDose($0.value)
             return TreatmentPoint(
                 date: Date(timeIntervalSince1970: $0.date),
@@ -446,7 +454,7 @@ final class BGChartModel: ObservableObject {
                 pillText: "Bolus\n\(dose)U\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))"
             )
         }
-        carbs = Self.spread(vc.carbData.map {
+        carbs = Self.spread((showCarbs ? vc.carbData : []).map {
             let grams = Int($0.value)
             var label = "\(grams)"
             if $0.absorptionTime > 0, Storage.shared.showAbsorption.value {
@@ -460,7 +468,7 @@ final class BGChartModel: ObservableObject {
                 pillText: "Carbs\n\(grams)g\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))"
             )
         }, minGap: Spread.carbGap, maxShift: Spread.carbShift)
-        let smbPoints = vc.smbData.map {
+        let smbPoints = (showBolus ? vc.smbData : []).map {
             let dose = self.formatDose($0.value)
             return TreatmentPoint(
                 date: Date(timeIntervalSince1970: $0.date),
@@ -471,7 +479,7 @@ final class BGChartModel: ObservableObject {
             )
         }
         (boluses, smbs) = Self.spreadTogether(bolusPoints, smbPoints, minGap: Spread.bolusGap, maxShift: Spread.bolusShift)
-        bgChecks = vc.bgCheckData.map {
+        bgChecks = (showOtherTreatments ? vc.bgCheckData : []).map {
             TreatmentPoint(
                 date: Date(timeIntervalSince1970: $0.date),
                 value: Double($0.sgv),
@@ -480,16 +488,16 @@ final class BGChartModel: ObservableObject {
                 pillText: "BG Check\n\(Localizer.toDisplayUnits(String($0.sgv)))\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))"
             )
         }
-        suspends = vc.suspendGraphData.map {
+        suspends = (showOtherTreatments ? vc.suspendGraphData : []).map {
             TreatmentPoint(date: Date(timeIntervalSince1970: $0.date), value: Double($0.sgv), sgv: Double($0.sgv), label: "", pillText: "Suspend\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))")
         }
-        resumes = vc.resumeGraphData.map {
+        resumes = (showOtherTreatments ? vc.resumeGraphData : []).map {
             TreatmentPoint(date: Date(timeIntervalSince1970: $0.date), value: Double($0.sgv), sgv: Double($0.sgv), label: "", pillText: "Resume\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))")
         }
-        sensorStarts = vc.sensorStartGraphData.map {
+        sensorStarts = (showOtherTreatments ? vc.sensorStartGraphData : []).map {
             TreatmentPoint(date: Date(timeIntervalSince1970: $0.date), value: Double($0.sgv), sgv: Double($0.sgv), label: "", pillText: "Sensor Start\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))")
         }
-        notes = vc.noteGraphData.map {
+        notes = (showOtherTreatments ? vc.noteGraphData : []).map {
             TreatmentPoint(
                 date: Date(timeIntervalSince1970: $0.date),
                 value: Double($0.sgv),
@@ -499,12 +507,12 @@ final class BGChartModel: ObservableObject {
             )
         }
 
-        basalScheduled = vc.basalScheduleData.map {
+        basalScheduled = (showBasal ? vc.basalScheduleData : []).map {
             ScheduledBasalPoint(date: Date(timeIntervalSince1970: $0.date), rate: $0.basalRate)
         }
 
         var steps: [BasalStep] = []
-        let sortedBasal = vc.basalData.sorted { $0.date < $1.date }
+        let sortedBasal = (showBasal ? vc.basalData : []).sorted { $0.date < $1.date }
         for i in 0 ..< sortedBasal.count {
             let start = sortedBasal[i].date
             let end = i + 1 < sortedBasal.count
@@ -523,7 +531,7 @@ final class BGChartModel: ObservableObject {
 
         let yTop = maxBG - 5
         let yBottom = maxBG - 25
-        overrides = vc.overrideGraphData.map {
+        overrides = (showOtherTreatments ? vc.overrideGraphData : []).map {
             let overrideName = $0.reason.trimmingCharacters(in: .whitespacesAndNewlines)
             let displayName = overrideName.isEmpty ? "Override" : overrideName
             return BandRect(
@@ -535,7 +543,7 @@ final class BGChartModel: ObservableObject {
                 pillText: "Override\n\(displayName)\n\(pillTimeString(for: Date(timeIntervalSince1970: $0.date)))"
             )
         }
-        tempTargets = vc.tempTargetGraphData.map {
+        tempTargets = (showOtherTreatments ? vc.tempTargetGraphData : []).map {
             let target = $0.correctionRange.first.map { String($0) } ?? ""
             // Temp targets render at the BG level they target (±5 mg/dL);
             // only overrides live in the top strip.

--- a/LoopFollow/Charts/BGChartStubs.swift
+++ b/LoopFollow/Charts/BGChartStubs.swift
@@ -22,6 +22,15 @@ extension MainViewController {
 
     func updateBGGraphSettings() {
         chartModel.rebuild()
+
+        // Re-route the stored predBGs in case the prediction style
+        // (cone/lines) changed; rebuild() alone only redraws what was
+        // already routed.
+        updateOpenAPSPredictionDisplay()
+
+        // The yesterday overlay is built during the BG fetch and needs an
+        // extra day of history, so reload the BG window when it's toggled.
+        TaskScheduler.shared.rescheduleTask(id: .fetchBG, to: Date())
     }
 
     private func recomputeTopBG() {

--- a/LoopFollow/Settings/AdvancedSettingsViewModel.swift
+++ b/LoopFollow/Settings/AdvancedSettingsViewModel.swift
@@ -19,24 +19,28 @@ class AdvancedSettingsViewModel: ObservableObject {
     @Published var graphBasal: Bool {
         didSet {
             Storage.shared.graphBasal.value = graphBasal
+            Observable.shared.chartSettingsChanged.value = true
         }
     }
 
     @Published var graphBolus: Bool {
         didSet {
             Storage.shared.graphBolus.value = graphBolus
+            Observable.shared.chartSettingsChanged.value = true
         }
     }
 
     @Published var graphCarbs: Bool {
         didSet {
             Storage.shared.graphCarbs.value = graphCarbs
+            Observable.shared.chartSettingsChanged.value = true
         }
     }
 
     @Published var graphOtherTreatments: Bool {
         didSet {
             Storage.shared.graphOtherTreatments.value = graphOtherTreatments
+            Observable.shared.chartSettingsChanged.value = true
         }
     }
 


### PR DESCRIPTION
The Graph Basal, Graph Bolus, Graph Carbs and Graph Other Treatments toggles in Advanced Settings stopped working in 7.0. The old chart only drew what the gated update calls pushed into it, but the new chart model reads the data arrays directly, so the toggles were never consulted. The model now skips the corresponding data when a toggle is off, and flipping a toggle marks the chart dirty so the graph redraws when you return to the home screen.

Two more settings-change behaviors were lost in the migration and are restored here: changing the prediction style re-routes the stored predBGs again, so switching between cone and lines no longer waits for the next device status fetch, and toggling Show Yesterday's BG reloads the BG window so the overlay appears or disappears right away instead of at the next scheduled fetch.

Verified in the simulator against a live Nightscout site: each toggle hides and restores its elements on both the main and the small graph, and the yesterday line appears within seconds of enabling it.

Fixes #728