### PR TITLE
Bugfix hover repeat entries

### DIFF
--- a/LoopFollow/Charts/BGChartScrubAttachment.swift
+++ b/LoopFollow/Charts/BGChartScrubAttachment.swift
@@ -8,6 +8,24 @@ struct BGChartHorizontalScrubCandidate<Value> {
     let plotX: CGFloat
 }
 
+func nearestBGChartHorizontalScrubCandidate<Value>(
+    in candidates: [BGChartHorizontalScrubCandidate<Value>],
+    to cursorX: CGFloat,
+    captureRadius: CGFloat
+) -> BGChartHorizontalScrubCandidate<Value>? {
+    var nearest: BGChartHorizontalScrubCandidate<Value>?
+    var nearestDistance = CGFloat.greatestFiniteMagnitude
+
+    for candidate in candidates {
+        let distance = abs(candidate.plotX - cursorX)
+        guard distance <= captureRadius, distance < nearestDistance else { continue }
+        nearest = candidate
+        nearestDistance = distance
+    }
+
+    return nearest
+}
+
 func horizontallyAdvancedBGChartScrubSelection<Value>(
     current: BGChartHorizontalScrubCandidate<Value>,
     proposals: [BGChartHorizontalScrubCandidate<Value>],

--- a/LoopFollow/Charts/BGChartScrubAttachment.swift
+++ b/LoopFollow/Charts/BGChartScrubAttachment.swift
@@ -1,0 +1,19 @@
+// LoopFollow
+// BGChartScrubAttachment.swift
+
+import CoreGraphics
+
+func bgChartScrubProbeLocation(
+    fingerLocation: CGPoint,
+    trackedPlotY: CGFloat?
+) -> CGPoint {
+    guard let trackedPlotY, trackedPlotY.isFinite else { return fingerLocation }
+    return CGPoint(x: fingerLocation.x, y: trackedPlotY)
+}
+
+func retainedBGChartScrubSelection<Value>(
+    current: Value?,
+    proposed: Value?
+) -> Value? {
+    proposed ?? current
+}

--- a/LoopFollow/Charts/BGChartScrubAttachment.swift
+++ b/LoopFollow/Charts/BGChartScrubAttachment.swift
@@ -3,17 +3,26 @@
 
 import CoreGraphics
 
-func bgChartScrubProbeLocation(
-    fingerLocation: CGPoint,
-    trackedPlotY: CGFloat?
-) -> CGPoint {
-    guard let trackedPlotY, trackedPlotY.isFinite else { return fingerLocation }
-    return CGPoint(x: fingerLocation.x, y: trackedPlotY)
+struct BGChartHorizontalScrubCandidate<Value> {
+    let value: Value
+    let plotX: CGFloat
 }
 
-func retainedBGChartScrubSelection<Value>(
-    current: Value?,
-    proposed: Value?
-) -> Value? {
-    proposed ?? current
+func horizontallyAdvancedBGChartScrubSelection<Value>(
+    current: BGChartHorizontalScrubCandidate<Value>,
+    proposals: [BGChartHorizontalScrubCandidate<Value>],
+    cursorX: CGFloat,
+    captureRadius: CGFloat
+) -> Value {
+    var best = current
+    var bestDistance = abs(current.plotX - cursorX)
+
+    for proposal in proposals {
+        let distance = abs(proposal.plotX - cursorX)
+        guard distance <= captureRadius, distance < bestDistance else { continue }
+        best = proposal
+        bestDistance = distance
+    }
+
+    return best.value
 }

--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -527,13 +527,37 @@ private struct MainBGChart: View {
     }
 
     private func updateSelection(at location: CGPoint, viewportWidth: CGFloat) {
-        let trackedPlotY = selection.map { yPosition(forValue: $0.value) }
-        let probeLocation = bgChartScrubProbeLocation(
-            fingerLocation: location,
-            trackedPlotY: trackedPlotY
-        )
-        let proposed = tappedAnchor(at: probeLocation, viewportWidth: viewportWidth)
-        selection = retainedBGChartScrubSelection(current: selection, proposed: proposed)
+        if let current = selection {
+            let laneProbe = CGPoint(x: location.x, y: yPosition(forValue: current.value))
+            let cursorDate = interaction.scrollPosition.addingTimeInterval(
+                interaction.visibleSeconds * TimeInterval(location.x / viewportWidth)
+            )
+            let proposals = [
+                tappedAnchor(at: laneProbe, viewportWidth: viewportWidth),
+                selectionAnchor(for: cursorDate, captureWindow: 0),
+            ].compactMap { anchor in
+                anchor.map {
+                    BGChartHorizontalScrubCandidate(
+                        value: $0,
+                        plotX: xPosition(for: $0.date, viewportWidth: viewportWidth)
+                    )
+                }
+            }
+
+            selection = horizontallyAdvancedBGChartScrubSelection(
+                current: BGChartHorizontalScrubCandidate(
+                    value: current,
+                    plotX: xPosition(for: current.date, viewportWidth: viewportWidth)
+                ),
+                proposals: proposals,
+                cursorX: location.x,
+                captureRadius: BGChartConfig.tapHitRadius
+            )
+        } else {
+            // The first contact stays fully 2D so overlapping event types can
+            // still be selected by touching their visible symbol.
+            selection = tappedAnchor(at: location, viewportWidth: viewportWidth)
+        }
 
         // A featherlight tick whenever the finger moves onto a different mark.
         if let anchor = selection, anchor.date != lastHapticAnchorDate {

--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -148,8 +148,8 @@ private struct MainBGChart: View {
     /// Leading edge captured when a one-finger drag transitions into panning.
     @State private var panBaseline: Date?
 
-    /// Date under the user's finger while inspecting, else nil.
-    @State private var selection: Date?
+    /// Exact plotted event under the user's finger while inspecting, else nil.
+    @State private var selection: SelectionAnchor?
 
     /// Anchor selected by tapping a mark; sticky until the user taps empty
     /// space, taps another mark, or starts a pan/zoom/inspect.
@@ -439,7 +439,7 @@ private struct MainBGChart: View {
                 }
 
                 if isInspectLatched {
-                    updateSelection(atViewportX: value.location.x, viewportWidth: viewportWidth)
+                    updateSelection(at: value.location, viewportWidth: viewportWidth)
                     return
                 }
 
@@ -521,20 +521,15 @@ private struct MainBGChart: View {
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
             scrubHaptic.prepare()
             if let location = lastTouchLocation {
-                updateSelection(atViewportX: location.x, viewportWidth: viewportWidth)
+                updateSelection(at: location, viewportWidth: viewportWidth)
             }
         }
     }
 
-    private func updateSelection(atViewportX x: CGFloat, viewportWidth: CGFloat) {
-        let fraction = min(max(x / viewportWidth, 0), 1)
-        let date = interaction.scrollPosition.addingTimeInterval(
-            interaction.visibleSeconds * TimeInterval(fraction)
-        )
-        selection = date
-        // A featherlight tick whenever the indicator snaps to a different item.
-        let captureWindow = scrubCaptureWindow(viewportWidth: viewportWidth)
-        if let anchor = selectionAnchor(for: date, captureWindow: captureWindow), anchor.date != lastHapticAnchorDate {
+    private func updateSelection(at location: CGPoint, viewportWidth: CGFloat) {
+        selection = tappedAnchor(at: location, viewportWidth: viewportWidth)
+        // A featherlight tick whenever the finger moves onto a different mark.
+        if let anchor = selection, anchor.date != lastHapticAnchorDate {
             lastHapticAnchorDate = anchor.date
             scrubHaptic.selectionChanged()
             scrubHaptic.prepare()
@@ -854,9 +849,9 @@ private struct MainBGChart: View {
     }
 
     /// The anchor the overlay should show: a live scrub wins over a sticky tap.
-    private func activeAnchor(viewportWidth: CGFloat) -> SelectionAnchor? {
-        if isInspectLatched, let selected = selection {
-            return selectionAnchor(for: selected, captureWindow: scrubCaptureWindow(viewportWidth: viewportWidth))
+    private func activeAnchor(viewportWidth _: CGFloat) -> SelectionAnchor? {
+        if isInspectLatched {
+            return selection
         }
         return tapped
     }

--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -527,7 +527,14 @@ private struct MainBGChart: View {
     }
 
     private func updateSelection(at location: CGPoint, viewportWidth: CGFloat) {
-        selection = tappedAnchor(at: location, viewportWidth: viewportWidth)
+        let trackedPlotY = selection.map { yPosition(forValue: $0.value) }
+        let probeLocation = bgChartScrubProbeLocation(
+            fingerLocation: location,
+            trackedPlotY: trackedPlotY
+        )
+        let proposed = tappedAnchor(at: probeLocation, viewportWidth: viewportWidth)
+        selection = retainedBGChartScrubSelection(current: selection, proposed: proposed)
+
         // A featherlight tick whenever the finger moves onto a different mark.
         if let anchor = selection, anchor.date != lastHapticAnchorDate {
             lastHapticAnchorDate = anchor.date

--- a/LoopFollow/Charts/BGChartView.swift
+++ b/LoopFollow/Charts/BGChartView.swift
@@ -533,8 +533,12 @@ private struct MainBGChart: View {
                 interaction.visibleSeconds * TimeInterval(location.x / viewportWidth)
             )
             let proposals = [
+                nearestTreatmentScrubAnchor(atViewportX: location.x, viewportWidth: viewportWidth),
                 tappedAnchor(at: laneProbe, viewportWidth: viewportWidth),
-                selectionAnchor(for: cursorDate, captureWindow: 0),
+                // Treatments are proposed independently above. A negative
+                // window keeps this dense-series lookup from rebuilding the
+                // old multi-treatment popup at an exact timestamp.
+                selectionAnchor(for: cursorDate, captureWindow: -1),
             ].compactMap { anchor in
                 anchor.map {
                     BGChartHorizontalScrubCandidate(
@@ -565,6 +569,49 @@ private struct MainBGChart: View {
             scrubHaptic.selectionChanged()
             scrubHaptic.prepare()
         }
+    }
+
+    /// Finds the closest treatment by rendered X only, then resolves its pill
+    /// through the normal 2-D hit test at the mark's exact plotted position.
+    /// This keeps sparse SMB, carb, and bolus marks reachable after the scrub
+    /// has detached vertically from the finger.
+    private func nearestTreatmentScrubAnchor(
+        atViewportX cursorX: CGFloat,
+        viewportWidth: CGFloat
+    ) -> SelectionAnchor? {
+        let groups = [
+            model.boluses,
+            model.carbs,
+            model.smbs,
+            model.bgChecks,
+            model.notes,
+            model.suspends,
+            model.resumes,
+            model.sensorStarts,
+        ]
+        let candidates = groups.flatMap { group in
+            group.map { treatment in
+                BGChartHorizontalScrubCandidate(
+                    value: treatment,
+                    plotX: xPosition(for: treatment.drawnDate, viewportWidth: viewportWidth)
+                )
+            }
+        }
+        guard let nearest = nearestBGChartHorizontalScrubCandidate(
+            in: candidates,
+            to: cursorX,
+            captureRadius: BGChartConfig.tapHitRadius
+        ) else {
+            return nil
+        }
+
+        return tappedAnchor(
+            at: CGPoint(
+                x: nearest.plotX,
+                y: yPosition(forValue: nearest.value.sgv)
+            ),
+            viewportWidth: viewportWidth
+        )
     }
 
     /// Deceleration after a flick. Mutates only scrollPosition (a transform),

--- a/Tests/Charts/BGChartScrubAttachmentTests.swift
+++ b/Tests/Charts/BGChartScrubAttachmentTests.swift
@@ -6,60 +6,113 @@ import CoreGraphics
 import Testing
 
 struct BGChartScrubAttachmentTests {
-    @Test("initial scrub uses the finger's full position")
-    func unattachedProbeUsesFingerPosition() {
-        let finger = CGPoint(x: 120, y: 280)
-
-        #expect(bgChartScrubProbeLocation(fingerLocation: finger, trackedPlotY: nil) == finger)
+    private enum Event: Equatable {
+        case smb(Int)
+        case bg(Int)
+        case cob(Int)
     }
 
-    @Test("attached scrub follows finger horizontally while ignoring vertical movement")
-    func attachedProbeUsesTrackedPlotHeight() {
-        let movedFinger = CGPoint(x: 175, y: 20)
+    @Test("closer BG wins while an SMB remains inside the capture radius")
+    func closerBGBeatsNearbySMB() {
+        let selected = resolve(
+            current: candidate(.smb(1), x: 125),
+            proposals: [candidate(.smb(1), x: 125), candidate(.bg(140), x: 140)],
+            cursorX: 140
+        )
+
+        #expect(selected == .bg(140))
+    }
+
+    @Test("scrub visits the BG entries between two SMBs")
+    func visitsBGsBetweenSMBs() {
+        let candidates = [
+            candidate(.smb(1), x: 100),
+            candidate(.bg(120), x: 120),
+            candidate(.bg(140), x: 140),
+            candidate(.bg(160), x: 160),
+            candidate(.smb(2), x: 180),
+        ]
+        var current = candidates[0]
+        var selected: [Event] = []
+
+        for cursorX in [100, 120, 140, 160, 180] as [CGFloat] {
+            let value = resolve(current: current, proposals: candidates, cursorX: cursorX)
+            selected.append(value)
+            current = candidates.first(where: { $0.value == value })!
+        }
+
+        #expect(selected == [.smb(1), .bg(120), .bg(140), .bg(160), .smb(2)])
+    }
+
+    @Test("scrub visits the same entries in reverse")
+    func visitsBGsInReverse() {
+        let candidates = [
+            candidate(.smb(1), x: 100),
+            candidate(.bg(120), x: 120),
+            candidate(.bg(140), x: 140),
+            candidate(.bg(160), x: 160),
+            candidate(.smb(2), x: 180),
+        ]
+        var current = candidates[4]
+        var selected: [Event] = []
+
+        for cursorX in [180, 160, 140, 120, 100] as [CGFloat] {
+            let value = resolve(current: current, proposals: candidates, cursorX: cursorX)
+            selected.append(value)
+            current = candidates.first(where: { $0.value == value })!
+        }
+
+        #expect(selected == [.smb(2), .bg(160), .bg(140), .bg(120), .smb(1)])
+    }
+
+    @Test("candidate order cannot hide the closest entry")
+    func candidateOrderDoesNotMatter() {
+        let current = candidate(.smb(1), x: 100)
+        let proposals = [candidate(.smb(2), x: 145), candidate(.bg(140), x: 140)]
+
+        #expect(resolve(current: current, proposals: proposals, cursorX: 140) == .bg(140))
+        #expect(resolve(current: current, proposals: Array(proposals.reversed()), cursorX: 140) == .bg(140))
+    }
+
+    @Test("an exact horizontal tie preserves the attached event type")
+    func tiePreservesCurrentEvent() {
+        let current = candidate(.cob(20), x: 140)
 
         #expect(
-            bgChartScrubProbeLocation(
-                fingerLocation: movedFinger,
-                trackedPlotY: 240
-            ) == CGPoint(x: 175, y: 240)
+            resolve(
+                current: current,
+                proposals: [candidate(.bg(140), x: 140)],
+                cursorX: 140
+            ) == .cob(20)
         )
     }
 
-    @Test("tracked height advances with the newly selected point")
-    func probeFollowsUpdatedPlotHeight() {
-        let finger = CGPoint(x: 210, y: 350)
-
+    @Test("a true horizontal gap retains the attached entry")
+    func gapRetainsCurrentEvent() {
         #expect(
-            bgChartScrubProbeLocation(
-                fingerLocation: finger,
-                trackedPlotY: 195
-            ) == CGPoint(x: 210, y: 195)
-        )
-        #expect(
-            bgChartScrubProbeLocation(
-                fingerLocation: finger,
-                trackedPlotY: 170
-            ) == CGPoint(x: 210, y: 170)
+            resolve(
+                current: candidate(.bg(100), x: 100),
+                proposals: [candidate(.bg(160), x: 160)],
+                cursorX: 200
+            ) == .bg(100)
         )
     }
 
-    @Test("temporary misses retain the attached selection")
-    func missRetainsCurrentSelection() {
-        #expect(
-            retainedBGChartScrubSelection(
-                current: "current SMB",
-                proposed: nil
-            ) == "current SMB"
-        )
+    private func candidate(_ value: Event, x: CGFloat) -> BGChartHorizontalScrubCandidate<Event> {
+        BGChartHorizontalScrubCandidate(value: value, plotX: x)
     }
 
-    @Test("a newly resolved point advances the selection")
-    func proposalReplacesCurrentSelection() {
-        #expect(
-            retainedBGChartScrubSelection(
-                current: "current BG",
-                proposed: "next BG"
-            ) == "next BG"
+    private func resolve(
+        current: BGChartHorizontalScrubCandidate<Event>,
+        proposals: [BGChartHorizontalScrubCandidate<Event>],
+        cursorX: CGFloat,
+        radius: CGFloat = 30
+    ) -> Event {
+        horizontallyAdvancedBGChartScrubSelection(
+            current: current,
+            proposals: proposals,
+            cursorX: cursorX,
+            captureRadius: radius
         )
     }
 }

--- a/Tests/Charts/BGChartScrubAttachmentTests.swift
+++ b/Tests/Charts/BGChartScrubAttachmentTests.swift
@@ -1,0 +1,65 @@
+// LoopFollow
+// BGChartScrubAttachmentTests.swift
+
+import CoreGraphics
+@testable import LoopFollow
+import Testing
+
+struct BGChartScrubAttachmentTests {
+    @Test("initial scrub uses the finger's full position")
+    func unattachedProbeUsesFingerPosition() {
+        let finger = CGPoint(x: 120, y: 280)
+
+        #expect(bgChartScrubProbeLocation(fingerLocation: finger, trackedPlotY: nil) == finger)
+    }
+
+    @Test("attached scrub follows finger horizontally while ignoring vertical movement")
+    func attachedProbeUsesTrackedPlotHeight() {
+        let movedFinger = CGPoint(x: 175, y: 20)
+
+        #expect(
+            bgChartScrubProbeLocation(
+                fingerLocation: movedFinger,
+                trackedPlotY: 240
+            ) == CGPoint(x: 175, y: 240)
+        )
+    }
+
+    @Test("tracked height advances with the newly selected point")
+    func probeFollowsUpdatedPlotHeight() {
+        let finger = CGPoint(x: 210, y: 350)
+
+        #expect(
+            bgChartScrubProbeLocation(
+                fingerLocation: finger,
+                trackedPlotY: 195
+            ) == CGPoint(x: 210, y: 195)
+        )
+        #expect(
+            bgChartScrubProbeLocation(
+                fingerLocation: finger,
+                trackedPlotY: 170
+            ) == CGPoint(x: 210, y: 170)
+        )
+    }
+
+    @Test("temporary misses retain the attached selection")
+    func missRetainsCurrentSelection() {
+        #expect(
+            retainedBGChartScrubSelection(
+                current: "current SMB",
+                proposed: nil
+            ) == "current SMB"
+        )
+    }
+
+    @Test("a newly resolved point advances the selection")
+    func proposalReplacesCurrentSelection() {
+        #expect(
+            retainedBGChartScrubSelection(
+                current: "current BG",
+                proposed: "next BG"
+            ) == "next BG"
+        )
+    }
+}

--- a/Tests/Charts/BGChartScrubAttachmentTests.swift
+++ b/Tests/Charts/BGChartScrubAttachmentTests.swift
@@ -8,8 +8,11 @@ import Testing
 struct BGChartScrubAttachmentTests {
     private enum Event: Equatable {
         case smb(Int)
+        case carb(Int)
+        case bolus(Int)
         case bg(Int)
         case cob(Int)
+        case composite
     }
 
     @Test("closer BG wins while an SMB remains inside the capture radius")
@@ -74,6 +77,17 @@ struct BGChartScrubAttachmentTests {
         #expect(resolve(current: current, proposals: Array(proposals.reversed()), cursorX: 140) == .bg(140))
     }
 
+    @Test("an explicit treatment wins a same-position composite proposal")
+    func explicitTreatmentWinsCompositeTie() {
+        let current = candidate(.bg(100), x: 100)
+        let proposals = [
+            candidate(.bolus(2), x: 140),
+            candidate(.composite, x: 140),
+        ]
+
+        #expect(resolve(current: current, proposals: proposals, cursorX: 140) == .bolus(2))
+    }
+
     @Test("an exact horizontal tie preserves the attached event type")
     func tiePreservesCurrentEvent() {
         let current = candidate(.cob(20), x: 140)
@@ -98,6 +112,27 @@ struct BGChartScrubAttachmentTests {
         )
     }
 
+    @Test("each sparse treatment kind remains reachable by horizontal position")
+    func treatmentKindsRemainReachable() {
+        let candidates = [
+            candidate(.smb(1), x: 100),
+            candidate(.carb(20), x: 130),
+            candidate(.bolus(2), x: 160),
+        ]
+
+        #expect(nearest(in: candidates, cursorX: 100)?.value == .smb(1))
+        #expect(nearest(in: candidates, cursorX: 130)?.value == .carb(20))
+        #expect(nearest(in: candidates, cursorX: 160)?.value == .bolus(2))
+    }
+
+    @Test("a treatment outside the horizontal capture radius is ignored")
+    func distantTreatmentIsIgnored() {
+        let candidates = [candidate(.bolus(1), x: 100)]
+
+        #expect(nearest(in: candidates, cursorX: 131) == nil)
+        #expect(nearest(in: candidates, cursorX: 130)?.value == .bolus(1))
+    }
+
     private func candidate(_ value: Event, x: CGFloat) -> BGChartHorizontalScrubCandidate<Event> {
         BGChartHorizontalScrubCandidate(value: value, plotX: x)
     }
@@ -112,6 +147,18 @@ struct BGChartScrubAttachmentTests {
             current: current,
             proposals: proposals,
             cursorX: cursorX,
+            captureRadius: radius
+        )
+    }
+
+    private func nearest(
+        in candidates: [BGChartHorizontalScrubCandidate<Event>],
+        cursorX: CGFloat,
+        radius: CGFloat = 30
+    ) -> BGChartHorizontalScrubCandidate<Event>? {
+        nearestBGChartHorizontalScrubCandidate(
+            in: candidates,
+            to: cursorX,
             captureRadius: radius
         )
     }


### PR DESCRIPTION
Without this fix, SMBs/boluses/etc can be duplicated when sliding the finger along the graph - making it look as if multiple SMBs/etc were sent when in fact only 1 was. This fixes that behavior so that each entry on the graph lives as its own distinct point when sliding across the graph.